### PR TITLE
M #-: Correctly enable crb and highavailability repos in RHEL (fix)

### DIFF
--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -21,7 +21,9 @@
   tags: [preinstall]
 
 # NOTE: In RedHat-like distros PostgreSQL is not initialized automatically..
-- when: package is changed and (ansible_os_family == 'RedHat' and db_backend == 'PostgreSQL')
+- when:
+    - package is defined and package is changed
+    - ansible_os_family == 'RedHat' and db_backend == 'PostgreSQL'
   block:
     - name: Check if PostgreSQL has been initialized
       ansible.builtin.stat:

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -77,7 +77,14 @@
   block:
     - name: Enable required DNF extra repos
       ansible.builtin.shell:
-        cmd: dnf config-manager -y --enable crb epel highavailability
+        cmd: |
+          set -o errexit
+          dnf config-manager -y --enable epel
+          if ! dnf config-manager -y --enable crb highavailability; then
+            RELEASE=$(rpm -q redhat-release | awk -F '[-.]' '{print $3}')
+            subscription-manager repos --enable codeready-builder-for-rhel-$RELEASE-x86_64-rpms \
+                                       --enable rhel-$RELEASE-for-x86_64-highavailability-rpms
+          fi
         executable: /bin/bash
       changed_when: false
 


### PR DESCRIPTION
- Assume that EPEL is pre-installed by the user
- Enable CRB and HA repos in ALMA / RHEL (different methods)
- Add fix for database role when "preinstall" tag is skipped