### PR TITLE
M #-: Add support for Passenger/Apache2 high-performance Sunstone

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
-features:
+features_defaults:
   gateproxy: true
   prometheus: false
+  passenger: false
 
 # We define it here, because it's used in both opennebula/* and gate/* roles.
 gate_endpoint: >-

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Compute facts
+  ansible.builtin.set_fact:
+    features: >-
+      {{ features_defaults | combine(features | d({})) }}

--- a/roles/gui/README.md
+++ b/roles/gui/README.md
@@ -11,13 +11,19 @@ N/A
 Role Variables
 --------------
 
-| Name                       | Type  | Default     | Example             | Description                                                                |
-|----------------------------|-------|-------------|---------------------|----------------------------------------------------------------------------|
-| `public_fireedge_endpoint` | `str` | conditional | (check below)       | Base URL (domain or IP-based) over which end-users can access the service. |
-| `one_token`                | `str` | undefined   | `asd123as:123asd12` | OpenNebula Enterprise Edition subscription token.                          |
-| `one_fqdn`                 | `str` | undefined   | `nebula.example.io` | Fully qualified domain name of the OpenNebula instance.                    |
-| `one_vip`                  | `str` | undefined   | `10.11.12.13`       | When OpenNebula is in HA mode it points to the Leader.                     |
-| `leader`                   | `str` | undefined   | `10.11.12.13`       | When OpenNebula is in HA mode it points to the Leader.                     |
+| Name                        | Type   | Default                                   | Example             | Description                                                                 |
+|-----------------------------|--------|-------------------------------------------|---------------------|-----------------------------------------------------------------------------|
+| `private_fireedge_endpoint` | `str`  | `http://localhost:2616`                   |                     | FireEdge URL used internally in Sunstone / reverse proxies (Passenger).     |
+| `public_fireedge_endpoint`  | `str`  | conditional                               | (check below)       | Base URL (domain or IP-based) over which end-users can access the service.  |
+| `one_token`                 | `str`  | undefined                                 | `asd123as:123asd12` | OpenNebula Enterprise Edition subscription token.                           |
+| `one_fqdn`                  | `str`  | undefined                                 | `nebula.example.io` | Fully qualified domain name of the OpenNebula instance.                     |
+| `one_vip`                   | `str`  | undefined                                 | `10.11.12.13`       | When OpenNebula is in HA mode it points to the Leader.                      |
+| `leader`                    | `str`  | undefined                                 | `10.11.12.13`       | When OpenNebula is in HA mode it points to the Leader.                      |
+| `features.passenger`        | `bool` | `false`                                   | (check below)       | Enable Passenger/Apache2 high-performance Sunstone.                         |
+| `apache2_http.managed`      | `bool` | `true`                                    | (check below)       | Enable Passenger/Apache2 over HTTP/80.                                      |
+| `apache2_https.managed`     | `bool` | `false`                                   | (check below)       | Enable Passenger/Apache2 over HTTPS/443.                                    |
+| `apache2_https.key`         | `str`  | `/etc/ssl/private/opennebula-key.pem`     |                     | Private key path on the target Front-end (the file must be readable).       |
+| `apache2_https.certchain`   | `str`  | `/etc/ssl/certs/opennebula-certchain.pem` |                     | Certificate chain path on the target Front-end (the file must be readable). |
 
 Dependencies
 ------------
@@ -30,6 +36,13 @@ Example Playbook
     - hosts: frontend
       vars:
         public_fireedge_endpoint: "https://nebula.example.io"
+        one_fqdn: "nebula.example.io"
+        features:
+          passenger: true # enable Passenger/Apache2 Sunstone
+        apache2_http:
+          managed: false # disable plain HTTP
+        apache2_https:
+          managed: true # enable HTTPS with the default key and certchain
       roles:
         - role: opennebula.deploy.helper.facts
         - role: opennebula.deploy.repository

--- a/roles/gui/defaults/main.yml
+++ b/roles/gui/defaults/main.yml
@@ -1,3 +1,32 @@
 ---
+private_fireedge_endpoint: >-
+  http://localhost:2616
+
 public_fireedge_endpoint: >-
-  http://{{ one_fqdn | d(one_vip) | d(hostvars[leader].ansible_host) }}:2616
+  {{ 'https://' ~ one_fqdn
+     if apache2_https.managed | bool is true else
+     'http://' ~ one_fqdn | d(one_vip) | d(hostvars[leader].ansible_host) ~ ':2616' }}
+
+passenger_repo_key_path:
+  Debian: /etc/apt/trusted.gpg.d/passenger.asc
+  RedHat: /etc/pki/rpm-gpg/RPM-GPG-KEY-passenger
+
+passenger_repo_key_url:
+  Debian: https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt
+  RedHat: https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt
+
+passenger_repo_path:
+  Debian: /etc/apt/sources.list.d/passenger.list
+  RedHat: /etc/yum.repos.d/passenger.repo
+
+passenger_repo_url:
+  Debian: https://oss-binaries.phusionpassenger.com/apt/passenger
+  RedHat: https://oss-binaries.phusionpassenger.com/yum/passenger/el
+
+apache2_http_defaults:
+  managed: true
+
+apache2_https_defaults:
+  managed: false
+  key: /etc/ssl/private/opennebula-key.pem
+  certchain: /etc/ssl/certs/opennebula-certchain.pem

--- a/roles/gui/handlers/main.yml
+++ b/roles/gui/handlers/main.yml
@@ -5,8 +5,20 @@
     state: restarted
   when: gui_no_restart is false
 
-- name: Restart Sunstone Server
+- name: Restart Sunstone
   ansible.builtin.service:
-    name: opennebula-sunstone
+    name: >-
+      {{ _name[ansible_os_family]
+         if features.passenger | bool is true else
+         'opennebula-sunstone' }}
     state: restarted
+  vars:
+    _name: { Debian: apache2, RedHat: httpd }
   when: gui_no_restart is false
+
+- name: Reload Apache2
+  ansible.builtin.service:
+    name: "{{ _name[ansible_os_family] }}"
+    state: reloaded
+  vars:
+    _name: { Debian: apache2, RedHat: httpd }

--- a/roles/gui/tasks/config.yml
+++ b/roles/gui/tasks/config.yml
@@ -1,11 +1,35 @@
 ---
+- name: Compute facts
+  ansible.builtin.set_fact:
+    apache2_http: >-
+      {{ apache2_http_defaults | combine(apache2_http | d({})) }}
+    apache2_https: >-
+      {{ apache2_https_defaults | combine(apache2_https | d({})) }}
+
+- name: Configure Sunstone Server (:private_fireedge_endpoint)
+  ansible.builtin.lineinfile:
+    path: /etc/one/sunstone-server.conf
+    regexp: '^:private_fireedge_endpoint:.*$'
+    line: ':private_fireedge_endpoint: "{{ private_fireedge_endpoint | lower }}"'
+  notify:
+    - Restart Sunstone
+
 - name: Configure Sunstone Server (:public_fireedge_endpoint)
   ansible.builtin.lineinfile:
     path: /etc/one/sunstone-server.conf
     regexp: '^:public_fireedge_endpoint:.*$'
     line: ':public_fireedge_endpoint: "{{ public_fireedge_endpoint | lower }}"'
   notify:
-    - Restart Sunstone Server
+    - Restart Sunstone
+
+- name: Configure Sunstone Server (:sessions)
+  ansible.builtin.lineinfile:
+    path: /etc/one/sunstone-server.conf
+    regexp: '^[#\s]*:sessions:.*$'
+    line: ':sessions: memcache'
+  notify:
+    - Restart Sunstone
+  when: features.passenger | bool is true
 
 - name: Configure Sunstone Server (:token_remote_support)
   ansible.builtin.lineinfile:
@@ -13,5 +37,5 @@
     regexp: '^[#\s]*:token_remote_support:.*$'
     line: ':token_remote_support: "{{ one_token }}"'
   notify:
-    - Restart Sunstone Server
+    - Restart Sunstone
   when: one_token is defined and one_token is truthy

--- a/roles/gui/tasks/main.yml
+++ b/roles/gui/tasks/main.yml
@@ -31,18 +31,31 @@
     state: started
   register: service_fireedge
 
-- name: Enable Sunstone Server (NOW)
-  ansible.builtin.service:
-    name: opennebula-sunstone
-    enabled: true
+- when: features.passenger | bool is false
+  block:
+    - name: Enable Sunstone Server (NOW)
+      ansible.builtin.service:
+        name: opennebula-sunstone
+        enabled: true
 
-- name: Start Sunstone Server (NOW)
-  ansible.builtin.service:
-    name: opennebula-sunstone
-    state: started
-  register: service_sunstone
+    - name: Start Sunstone Server (NOW)
+      ansible.builtin.service:
+        name: opennebula-sunstone
+        state: started
+      register: service_sunstone
 
-- name: Make sure FireEdge and Sunstone Servers are not restarted twice
+- when: features.passenger | bool is true
+  block:
+    - name: Disable / Stop Sunstone Server (NOW)
+      ansible.builtin.service:
+        name: opennebula-sunstone
+        enabled: false
+        state: stopped
+
+    - ansible.builtin.import_tasks:
+        file: "{{ role_path }}/tasks/passenger.yml"
+
+- name: Ensure FireEdge and Sunstone are not restarted twice
   ansible.builtin.set_fact:
     gui_no_restart: >-
       {{ service_fireedge is changed and service_sunstone is changed }}

--- a/roles/gui/tasks/passenger.yml
+++ b/roles/gui/tasks/passenger.yml
@@ -1,0 +1,167 @@
+---
+- tags: [preinstall]
+  block:
+    - name: Install Phusion Passenger dependencies
+      ansible.builtin.package:
+        name: "{{ _common + _specific[ansible_os_family] }}"
+      vars:
+        _common: [ca-certificates, gnupg2, memcached]
+        _specific:
+          Debian: [apt-transport-https, dirmngr, apache2]
+          RedHat: [httpd, mod_ssl]
+      register: package
+      until: package is success
+      retries: 12
+      delay: 5
+
+    # NOTE: All modules specified below are enabled automatically
+    # in RedHat-like distros.
+    - name: Enable Apache2 modules
+      ansible.builtin.command:
+        cmd: a2enmod '{{ item }}'
+        creates: "/etc/apache2/mods-enabled/{{ item }}.load"
+      loop: [headers, proxy, proxy_http, proxy_wstunnel, rewrite, ssl]
+      notify:
+        - Restart Sunstone
+      when: ansible_os_family == 'Debian'
+
+    - name: Check if Phusion Passenger GPG key is installed
+      ansible.builtin.stat:
+        path: "{{ passenger_repo_key_path[ansible_os_family] }}"
+        get_attributes: false
+        get_checksum: false
+        get_mime: false
+      register: stat
+
+    - when: stat.stat.exists is false
+      block:
+        - name: Download Phusion Passenger GPG key (once)
+          ansible.builtin.uri:
+            url: "{{ passenger_repo_key_url[ansible_os_family] }}"
+            return_content: true
+          run_once: true
+          register: uri
+
+        - name: Install Phusion Passenger GPG key
+          ansible.builtin.copy:
+            dest: "{{ passenger_repo_key_path[ansible_os_family] }}"
+            mode: u=rw,go=r
+            content: "{{ uri.content }}"
+
+    - name: Install Phusion Passenger package source
+      ansible.builtin.copy:
+        dest: "{{ passenger_repo_path[ansible_os_family] }}"
+        mode: u=rw,go=r
+        content: "{{ _content[ansible_os_family] }}"
+      vars:
+        _content:
+          Debian: |
+            deb {{ passenger_repo_url.Debian }} {{ ansible_distribution_release }} main
+          RedHat: |
+            [passenger]
+            name=passenger
+            baseurl={{ passenger_repo_url.RedHat }}/$releasever/$basearch
+            enabled=1
+            gpgkey=file://{{ passenger_repo_key_path.RedHat }}
+            gpgcheck=0
+            repo_gpgcheck=1
+            sslverify=1
+            sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+      register: copy
+
+    - when: ansible_pkg_mgr == 'apt'
+      block:
+        - name: Update APT cache
+          ansible.builtin.apt:
+            update_cache: true
+          when: copy is changed
+
+    - when: ansible_pkg_mgr == 'dnf'
+      block:
+        - name: Update DNF cache
+          ansible.builtin.dnf:
+            update_cache: true
+          when: copy is changed
+
+    - name: Install Phusion Passenger
+      ansible.builtin.package:
+        name: "{{ _common + _specific[ansible_os_family] }}"
+      vars:
+        _common: []
+        _specific:
+          Debian: [libapache2-mod-passenger]
+          RedHat: [mod_passenger]
+      register: package
+      until: package is success
+      retries: 12
+      delay: 5
+
+- name: Enable / Start Memcached (NOW)
+  ansible.builtin.service:
+    name: memcached
+    enabled: true
+    state: started
+
+- name: Ensure correct directory permissions
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - { mode: a+x, path: /var }
+    - { mode: a+x, path: /var/lib }
+    - { mode: a+x, path: /var/lib/one }
+    - { mode: a+x, path: /var/lib/one/.one }
+    - { mode: a+x, path: /var/lib/one/sunstone }
+
+- vars:
+    _destdir:
+      Debian: /etc/apache2/sites-available
+      RedHat: /etc/httpd/conf.d
+    _loop:
+      - name: opennebula
+        when: >-
+          {{ (apache2_http.managed | bool is true) }}
+      - name: opennebula-ssl
+        when: >-
+          {{ (apache2_https.managed | bool is true)
+             and
+             (apache2_https.key is defined and apache2_https.key is truthy)
+             and
+             (apache2_https.certchain is defined and apache2_https.certchain is truthy) }}
+  block:
+    - name: Configure OpenNebula VHOSTs (Apache2)
+      ansible.builtin.template:
+        dest: "{{ _destdir[ansible_os_family] }}/{{ item.name }}.conf"
+        src: "{{ role_path }}/templates/{{ item.name }}.conf.j2"
+        mode: u=rw,go=r
+      when:
+        - item.when is true
+      loop: "{{ _loop }}"
+      notify:
+        - Reload Apache2
+
+    - name: Enable OpenNebula VHOSTs (Apache2)
+      ansible.builtin.command:
+        cmd: a2ensite '{{ item.name }}'
+        creates: "/etc/apache2/sites-enabled/{{ item.name }}.conf"
+      when:
+        - item.when is true
+        - ansible_os_family == 'Debian'
+      loop: "{{ _loop }}"
+      notify:
+        - Reload Apache2
+
+- name: Enable Apache2 Server
+  ansible.builtin.service:
+    name: "{{ _name[ansible_os_family] }}"
+    enabled: true
+  vars:
+    _name: { Debian: apache2, RedHat: httpd }
+
+- name: Start Apache2 Server
+  ansible.builtin.service:
+    name: "{{ _name[ansible_os_family] }}"
+    state: started
+  vars:
+    _name: { Debian: apache2, RedHat: httpd }
+  register: service_sunstone

--- a/roles/gui/templates/opennebula-ssl.conf.j2
+++ b/roles/gui/templates/opennebula-ssl.conf.j2
@@ -1,0 +1,55 @@
+<VirtualHost *:443>
+  ServerName {{ one_fqdn | d(one_vip) | d(hostvars[leader].ansible_host) }}
+
+  SSLEngine on
+  SSLCertificateKeyFile {{ apache2_https.key }}
+  SSLCertificateFile    {{ apache2_https.certchain }}
+
+  # taken from:
+  #   https://bettercrypto.org
+  #   https://httpd.apache.org/docs/trunk/ssl/ssl_howto.html
+  SSLProtocol All -SSLv2 -SSLv3 -TLSv1 -TLSv1.1
+  SSLHonorCipherOrder On
+  SSLCompression off
+  Header always set Strict-Transport-Security "max-age=15768000"
+  SSLCipherSuite 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256'
+
+  PassengerUser oneadmin
+
+  # For OpenNebula >= 5.10, variables configuring dedicated directory
+  # with shipped Ruby gems must be set if these gems weren't explicitly
+  # disabled (by removing specified directory symlink).
+  SetEnv GEM_PATH /usr/share/one/gems/
+  SetEnv GEM_HOME /usr/share/one/gems/
+
+  # !!! Be sure to point DocumentRoot to 'public'!
+  DocumentRoot /usr/lib/one/sunstone/public
+  <Directory /usr/lib/one/sunstone/public>
+      # This relaxes Apache security settings.
+      AllowOverride all
+      # MultiViews must be turned off.
+      Options -MultiViews
+      # Uncomment this if you're on Apache >= 2.4:
+      Require all granted
+      Options FollowSymLinks
+  </Directory>
+
+  ProxyRequests     off
+  ProxyPreserveHost on
+
+  # no proxy for /error/ (Apache HTTPd errors messages)
+  ProxyPass /error/ !
+
+  ProxyPass        /fireedge {{ private_fireedge_endpoint }}/fireedge
+  ProxyPassReverse /fireedge {{ private_fireedge_endpoint }}/fireedge
+
+  RewriteEngine on
+  RewriteCond %{HTTP:Upgrade} websocket [NC]
+  RewriteCond %{HTTP:Connection} upgrade [NC]
+  RewriteRule ^/fireedge/?(.*) "{{ 'ws://%(hostname)s:%(port)s' % (private_fireedge_endpoint | urlsplit) }}/fireedge/$1" [P,L]
+
+  <Location /fireedge>
+      Order deny,allow
+      Allow from all
+  </Location>
+</VirtualHost>

--- a/roles/gui/templates/opennebula.conf.j2
+++ b/roles/gui/templates/opennebula.conf.j2
@@ -1,0 +1,42 @@
+<VirtualHost *:80>
+  ServerName {{ one_fqdn | d(one_vip) | d(hostvars[leader].ansible_host) }}
+
+  PassengerUser oneadmin
+
+  # For OpenNebula >= 5.10, variables configuring dedicated directory
+  # with shipped Ruby gems must be set if these gems weren't explicitly
+  # disabled (by removing specified directory symlink).
+  SetEnv GEM_PATH /usr/share/one/gems/
+  SetEnv GEM_HOME /usr/share/one/gems/
+
+  # !!! Be sure to point DocumentRoot to 'public'!
+  DocumentRoot /usr/lib/one/sunstone/public
+  <Directory /usr/lib/one/sunstone/public>
+      # This relaxes Apache security settings.
+      AllowOverride all
+      # MultiViews must be turned off.
+      Options -MultiViews
+      # Uncomment this if you're on Apache >= 2.4:
+      Require all granted
+      Options FollowSymLinks
+  </Directory>
+
+  ProxyRequests     off
+  ProxyPreserveHost on
+
+  # no proxy for /error/ (Apache HTTPd errors messages)
+  ProxyPass /error/ !
+
+  ProxyPass        /fireedge {{ private_fireedge_endpoint }}/fireedge
+  ProxyPassReverse /fireedge {{ private_fireedge_endpoint }}/fireedge
+
+  RewriteEngine on
+  RewriteCond %{HTTP:Upgrade} websocket [NC]
+  RewriteCond %{HTTP:Connection} upgrade [NC]
+  RewriteRule ^/fireedge/?(.*) "{{ 'ws://%(hostname)s:%(port)s' % (private_fireedge_endpoint | urlsplit) }}/fireedge/$1" [P,L]
+
+  <Location /fireedge>
+      Order deny,allow
+      Allow from all
+  </Location>
+</VirtualHost>


### PR DESCRIPTION
- Install Phusion Passenger from official DEB/RPM packages
- Configure Apache2 in Debian/RedHat-like distros (different methods)
- Support both plain HTTP and HTTPS
- Update README.md for the role
- Always merge "features" dict with defaults (fix)