### PR TITLE
M #-: Set SSH_PUBLIC_KEY parameter for oneadmin

### DIFF
--- a/roles/opennebula/common/defaults/main.yml
+++ b/roles/opennebula/common/defaults/main.yml
@@ -3,3 +3,4 @@ one_pass: null
 force_ha: false
 unsafe_migrations: true
 keep_empty_bridge: true
+admin_pubkey: "{{ _admin_pubkey_loaded }}"

--- a/roles/opennebula/server/README.md
+++ b/roles/opennebula/server/README.md
@@ -11,20 +11,21 @@ N/A
 Role Variables
 --------------
 
-| Name                | Type   | Default      | Example       | Description                                                     |
-|---------------------|--------|--------------|---------------|-----------------------------------------------------------------|
-| `one_pass`          | `str`  | `null`       | `asd123`      | Use specific password for the `oneadmin` user.                  |
-| `force_ha`          | `bool` | `false`      |               | Deploy OpenNebula in HA mode even with a single Frontend.       |
-| `unsafe_migrations` | `bool` | `true`       |               | Disable LibVirt's NFS/mountpoint checks.                        |
-| `keep_empty_bridge` | `bool` | `true`       |               | Make sure empty network bridges are never removed (from Nodes). |
-| `one_vip`           | `str`  | undefined    | `10.11.12.13` | When OpenNebula is in HA mode it points to the Leader.          |
-| `one_vip_if`        | `str`  | undefined    | `eth0`        | NIC device to assign the `one_vip` address to (on Frontends).   |
-| `one_vip_cidr`      | `int`  | undefined    | `24`          | CIDR prefix of the subnet `one_vip` is allocated in.            |
-| `db_backend`        | `str`  | `MariaDB`    |               | Can be `MariaDB` or `PostgreSQL`.                               |
-| `db_name`           | `str`  | `opennebula` |               | Name of the database/schema used by OpenNebula.                 |
-| `db_owner`          | `str`  | `oneadmin`   |               | User used by OpenNebula to access the database.                 |
-| `db_password`       | `str`  | `opennebula` |               | Password used by OpenNebula to authenticate the user.           |
-| `gate_endpoint`     | `str`  | conditional  | (check below) | An URL used to reach the OneGate endpoint (HTTP).               |
+| Name                | Type   | Default      | Example       | Description                                                                                         |
+|---------------------|--------|--------------|---------------|-----------------------------------------------------------------------------------------------------------------|
+| `one_pass`          | `str`  | `null`       | `asd123`      | Use specific password for the `oneadmin` user.                                                                  |
+| `force_ha`          | `bool` | `false`      |               | Deploy OpenNebula in HA mode even with a single Frontend.                                                       |
+| `unsafe_migrations` | `bool` | `true`       |               | Disable LibVirt's NFS/mountpoint checks.                                                                        |
+| `keep_empty_bridge` | `bool` | `true`       |               | Make sure empty network bridges are never removed (from Nodes).                                                 |
+| `one_vip`           | `str`  | undefined    | `10.11.12.13` | When OpenNebula is in HA mode it points to the Leader.                                                          |
+| `one_vip_if`        | `str`  | undefined    | `eth0`        | NIC device to assign the `one_vip` address to (on Frontends).                                                   |
+| `one_vip_cidr`      | `int`  | undefined    | `24`          | CIDR prefix of the subnet `one_vip` is allocated in.                                                            |
+| `db_backend`        | `str`  | `MariaDB`    |               | Can be `MariaDB` or `PostgreSQL`.                                                                               |
+| `db_name`           | `str`  | `opennebula` |               | Name of the database/schema used by OpenNebula.                                                                 |
+| `db_owner`          | `str`  | `oneadmin`   |               | User used by OpenNebula to access the database.                                                                 |
+| `db_password`       | `str`  | `opennebula` |               | Password used by OpenNebula to authenticate the user.                                                           |
+| `gate_endpoint`     | `str`  | conditional  | (check below) | An URL used to reach the OneGate endpoint (HTTP).                                                               |
+| `admin_pubkey`      | `str`  | loaded       | (check below) | SSH pubkey loaded from `/var/lib/one/.ssh/id_rsa.pub`, provided by the user (as string) or ignored when `null`. |
 
 Dependencies
 ------------
@@ -37,6 +38,7 @@ Example Playbook
     - hosts: frontend
       vars:
         gate_endpoint: "http://10.11.12.13:5030"
+        admin_pubkey: null  # ignore it
       roles:
         - role: opennebula.deploy.helper.facts
         - role: opennebula.deploy.repository

--- a/roles/opennebula/server/tasks/admin.yml
+++ b/roles/opennebula/server/tasks/admin.yml
@@ -1,0 +1,49 @@
+---
+- delegate_to: "{{ leader }}"
+  run_once: true
+  block:
+    - name: Slurp oneadmin's public key
+      ansible.builtin.slurp:
+        path: /var/lib/one/.ssh/id_rsa.pub
+      register: slurp
+
+    - name: Get oneadmin's user template
+      ansible.builtin.shell:
+        cmd: oneuser show oneadmin --json
+        executable: /bin/bash
+      register: shell
+      changed_when: false
+
+    - name: Update oneadmin's user template
+      ansible.builtin.shell:
+        cmd: |
+          set +o errexit
+          TEMPLATE="$(mktemp)"
+          tee "$TEMPLATE"
+          oneuser update oneadmin "$TEMPLATE"; RC="$?"
+          rm -f "$TEMPLATE"
+          exit "$RC"
+        stdin: |
+          {{ _combined | opennebula.deploy.to_one }}
+        executable: /bin/bash
+      when:
+        - admin_pubkey != None  # admin_pubkey: null
+        - admin_pubkey | d('') | trim | length > 0
+        - _combined | opennebula.deploy.to_one
+          !=
+          _template | opennebula.deploy.to_one
+      vars:
+        _document: >-
+          {{ shell.stdout | from_json }}
+        _template: >-
+          {{ _document.USER.TEMPLATE }}
+        _combined: >-
+          {{ _template | combine(_update, recursive=true) }}
+        # NOTE: The "_admin_pubkey_loaded" is used inside the "admin_pubkey" var / default.
+        # That way it can be overridden or disabled (with null) or it takes the value of
+        # existing public key from the Leader when left alone.
+        _update:
+          SSH_PUBLIC_KEY: >-
+            {{ admin_pubkey | d('') | trim }}
+        _admin_pubkey_loaded: >-
+          {{ slurp.content | b64decode }}

--- a/roles/opennebula/server/tasks/main.yml
+++ b/roles/opennebula/server/tasks/main.yml
@@ -28,3 +28,6 @@
 - ansible.builtin.include_tasks:
     file: "{{ role_path }}/tasks/solo.yml"
   when: use_ha is false
+
+- ansible.builtin.import_tasks:
+    file: "{{ role_path }}/tasks/admin.yml"


### PR DESCRIPTION
- It can be provided by the user in the inventory (as string)
- It can be ignored when set to null (admin_pubkey: null)
- By default it's loaded from /var/lib/one/.ssh/id_rsa.pub