### PR TITLE
M #-: Correctly enable TM_MAD=shared with pre-mounted datastores (fix)

### DIFF
--- a/roles/datastore/simple/tasks/common.yml
+++ b/roles/datastore/simple/tasks/common.yml
@@ -15,29 +15,25 @@
 
     - name: Parse Datastores
       ansible.builtin.set_fact:
-        ds_mounts: >-
-          {{ _mounts }}
-        ds_parsed: >-
-          {{ _datastores }}
         ds_items:
           image: >-
-            {{ _mounts.image | zip(_grouped.image) }}
+            {{ _mounts.image | d([None], true) | zip(_grouped.image) }}
           system: >-
-            {{ _mounts.system | zip(_grouped.system) }}
+            {{ _mounts.system | d([None], true) | zip(_grouped.system) }}
           file: >-
-            {{ _mounts.file | zip(_grouped.file) }}
+            {{ _mounts.file | d([None], true) | zip(_grouped.file) }}
       vars:
         _document: >-
           {{ shell.stdout | from_json }}
         _datastores: >-
-          {{ [_document.DATASTORE_POOL.DATASTORE | default([])] | flatten | list }}
+          {{ [_document.DATASTORE_POOL.DATASTORE | d([])] | flatten | list }}
         _mounts:
           image: >-
-            {{ ds.config.mounts | default([]) | selectattr('type', '==', 'image') }}
+            {{ ds.config.mounts | d([]) | selectattr('type', '==', 'image') }}
           system: >-
-            {{ ds.config.mounts | default([]) | selectattr('type', '==', 'system') }}
+            {{ ds.config.mounts | d([]) | selectattr('type', '==', 'system') }}
           file: >-
-            {{ ds.config.mounts | default([]) | selectattr('type', '==', 'file') }}
+            {{ ds.config.mounts | d([]) | selectattr('type', '==', 'file') }}
         _grouped:
           image: >-
             {{ _datastores | selectattr('TYPE', '==', '0') | sort(attribute='ID') }}

--- a/roles/datastore/simple/tasks/frontend.yml
+++ b/roles/datastore/simple/tasks/frontend.yml
@@ -15,7 +15,10 @@
 
       exit 78
     executable: /bin/bash
-  loop: "{{ range(ds_items.image | length) }}"
+  loop: >-
+    {{ range(ds_items.image | map(attribute=0)
+                            | select
+                            | count) }}
   vars:
     _mount_path: >-
       {{ ds_items.image[item].0.path | realpath }}
@@ -29,7 +32,10 @@
 
 - name: Setup datastore symlinks (file)
   ansible.builtin.shell: *shell
-  loop: "{{ range(ds_items.file | length) }}"
+  loop: >-
+    {{ range(ds_items.file | map(attribute=0)
+                           | select
+                           | count) }}
   vars:
     _mount_path: >-
       {{ ds_items.file[item].0.path | realpath }}

--- a/roles/datastore/simple/tasks/node.yml
+++ b/roles/datastore/simple/tasks/node.yml
@@ -17,7 +17,10 @@
 
           exit 78
         executable: /bin/bash
-      loop: "{{ range(ds_items.image | length) }}"
+      loop: >-
+        {{ range(ds_items.image | map(attribute=0)
+                                | select
+                                | count) }}
       vars:
         _mount_path: >-
           {{ ds_items.image[item].0.path | realpath }}
@@ -31,7 +34,10 @@
 
 - name: Setup datastore symlinks (system)
   ansible.builtin.shell: *shell
-  loop: "{{ range(ds_items.system | length) }}"
+  loop: >-
+    {{ range(ds_items.system | map(attribute=0)
+                             | select
+                             | count) }}
   vars:
     _mount_path: >-
       {{ ds_items.system[item].0.path | realpath }}


### PR DESCRIPTION
Handle the case when /var/lib/one/datastores/ is pre-mounted by the user and ds.mode is 'shared' with no symlinks.