### PR TITLE
M #-: Use ~ operator correctly + use ansible_host (fix)

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -8,4 +8,4 @@ features_defaults:
 gate_endpoint: >-
   {{ 'http://169.254.16.9:5030'
      if features.gateproxy | bool is true else
-     'http://' ~ one_vip | d(leader) | d(groups[frontend_group | d('frontend')][0]) ~ ':5030' }}
+     'http://' ~ (one_vip | d(hostvars[leader | d(groups[frontend_group | d('frontend')][0])].ansible_host)) ~ ':5030' }}

--- a/roles/gui/defaults/main.yml
+++ b/roles/gui/defaults/main.yml
@@ -3,9 +3,9 @@ private_fireedge_endpoint: >-
   http://localhost:2616
 
 public_fireedge_endpoint: >-
-  {{ 'https://' ~ one_fqdn
+  {{ 'https://' ~ (one_fqdn | d(one_vip) | d(hostvars[leader].ansible_host))
      if apache2_https.managed | bool is true else
-     'http://' ~ one_fqdn | d(one_vip) | d(hostvars[leader].ansible_host) ~ ':2616' }}
+     'http://' ~ (one_fqdn | d(one_vip) | d(hostvars[leader].ansible_host)) ~ ':2616' }}
 
 passenger_repo_key_path:
   Debian: /etc/apt/trusted.gpg.d/passenger.asc


### PR DESCRIPTION
- Fix default of gate_endpoint
- Fix default of public_fireedge_endpoint
- Use ansible_host where possible