### PR TITLE
M #-: Add Ceph datastores and Ceph cluster provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ __pycache__/
 !/inventory/local.yml
 !/inventory/shared.yml
 !/inventory/shared-generic.yml
+!/inventory/ceph.yml
+!/inventory/ceph-hci.yml

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "vendor/ceph-ansible"]
+	path = vendor/ceph-ansible
+	url = https://github.com/ceph/ceph-ansible.git
+	branch = stable-7.0

--- a/Makefile
+++ b/Makefile
@@ -15,16 +15,19 @@ VERBOSE ?= $(V)
 
 export
 
+# Make sure we source ANSIBLE_ settings from ansible.cfg exclusively.
+unexport $(filter ANSIBLE_%,$(.VARIABLES))
+
 .PHONY: all
 
 all: main
 
-.PHONY: pre site main
+.PHONY: pre ceph site main
 
-pre site main: _TAGS      := $(if $(TAGS),-t $(TAGS),)
-pre site main: _SKIP_TAGS := $(if $(SKIP_TAGS),--skip-tags $(SKIP_TAGS),)
-pre site main: _VERBOSE   := $(if $(VERBOSE),-$(VERBOSE),)
-pre site main:
+pre ceph site main: _TAGS      := $(if $(TAGS),-t $(TAGS),)
+pre ceph site main: _SKIP_TAGS := $(if $(SKIP_TAGS),--skip-tags $(SKIP_TAGS),)
+pre ceph site main: _VERBOSE   := $(if $(VERBOSE),-$(VERBOSE),)
+pre ceph site main:
 	cd $(SELF)/ && ansible-playbook $(_VERBOSE) -i $(INVENTORY) $(_TAGS) $(_SKIP_TAGS) opennebula.deploy.$@
 
 .PHONY: requirements build publish

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,22 +1,29 @@
 [defaults]
-collections_paths=./ansible_collections/
-inventory=./inventory/example.yml
-gathering=explicit
-host_key_checking=false
-display_skipped_hosts=true
-retry_files_enabled=false
-any_errors_fatal=true
-callbacks_enabled=profile_tasks
-stdout_callback=yaml
-timeout=30
+collections_paths = ./ansible_collections/
+action_plugins    = ./vendor/ceph-ansible/plugins/actions/
+callback_plugins  = ./vendor/ceph-ansible/plugins/callback/
+filter_plugins    = ./vendor/ceph-ansible/plugins/filter/
+roles_path        = ./vendor/ceph-ansible/roles/
+library           = ./vendor/ceph-ansible/library/
+module_utils      = ./vendor/ceph-ansible/module_utils/
+
+inventory             = ./inventory/example.yml
+gathering             = explicit
+host_key_checking     = false
+display_skipped_hosts = true
+retry_files_enabled   = false
+any_errors_fatal      = true
+callbacks_enabled     = profile_tasks
+stdout_callback       = yaml
+timeout               = 30
 
 [privilege_escalation]
-become=true
-become_user=root
+become      = true
+become_user = root
 
 [ssh_connection]
-pipelining=true
+pipelining = true
 # Uncomment to disable bastion:
-ssh_args=-q -o ControlMaster=auto -o ControlPersist=60s
+ssh_args = -q -o ControlMaster=auto -o ControlPersist=60s
 # Uncomment to enable bastion:
-#ssh_args=-q -o ControlMaster=auto -o ControlPersist=60s -F inventory/.one-deploy/bastion
+#ssh_args = -q -o ControlMaster=auto -o ControlPersist=60s -F inventory/.one-deploy/bastion

--- a/inventory/ceph-hci.yml
+++ b/inventory/ceph-hci.yml
@@ -1,0 +1,74 @@
+---
+all:
+  vars:
+    ansible_user: ubuntu
+    ensure_keys_for: [ubuntu, root]
+    one_pass: opennebulapass
+    one_version: '6.6'
+    features:
+      # Enable the "ceph" feature in one-deploy.
+      ceph: true
+    ds:
+      # Simple datastore setup - use built-in Ceph cluster for datastores 0 (system) and 1 (images).
+      mode: ceph
+    vn:
+      admin_net:
+        managed: true
+        template:
+          VN_MAD: bridge
+          PHYDEV: eth0
+          BRIDGE: br0
+          AR:
+            TYPE: IP4
+            IP: 172.20.0.200
+            SIZE: 48
+          NETWORK_ADDRESS: 172.20.0.0
+          NETWORK_MASK: 255.255.255.0
+          GATEWAY: 172.20.0.1
+          DNS: 172.20.0.1
+
+frontend:
+  hosts:
+    f1: { ansible_host: 172.20.0.6 }
+
+node:
+  hosts:
+    n1: { ansible_host: 172.20.0.7 }
+    n2: { ansible_host: 172.20.0.8 }
+    n3: { ansible_host: 172.20.0.9 }
+
+ceph:
+  children:
+    ? mons
+    ? mgrs
+    ? osds
+  vars:
+    osd_memory_target: 4294967296 # 4GiB (default)
+    # Assuming all osds are of equal size, setup resource limits and reservations
+    # for all osd systemd services.
+    ceph_osd_systemd_overrides:
+      Service:
+        CPUWeight: 200 # 100 is the kernel default
+        CPUQuota: 100% # 1 full core
+        MemoryMin: "{{ (0.75 * osd_memory_target) | int }}"
+        MemoryHigh: "{{ osd_memory_target | int }}"
+    # Make sure osds preserve memory if it's below the value of the "osd_memory_target" fact.
+    ceph_conf_overrides:
+      osd:
+        ? osd memory target
+        : "{{ osd_memory_target | int }}"
+
+mons:
+  hosts:
+    f1: { ansible_host: 172.20.0.6, monitor_address: 172.20.0.6 }
+
+mgrs:
+  hosts:
+    f1: { ansible_host: 172.20.0.6 }
+
+osds:
+  hosts:
+    # NOTE: The Ceph osds are deployed along the OpenNebula KVM nodes (HCI setup).
+    n1: { ansible_host: 172.20.0.7 }
+    n2: { ansible_host: 172.20.0.8 }
+    n3: { ansible_host: 172.20.0.9 }

--- a/inventory/ceph.yml
+++ b/inventory/ceph.yml
@@ -1,0 +1,57 @@
+---
+all:
+  vars:
+    ansible_user: root
+    one_version: '6.6'
+    one_pass: opennebulapass
+    features:
+      # Enable the "ceph" feature in one-deploy.
+      ceph: true
+    ds:
+      # Simple datastore setup - use built-in Ceph cluster for datastores 0 (system) and 1 (images).
+      mode: ceph
+    vn:
+      admin_net:
+        managed: true
+        template:
+          VN_MAD: bridge
+          PHYDEV: eth0
+          BRIDGE: br0
+          AR:
+            TYPE: IP4
+            IP: 172.20.0.100
+            SIZE: 48
+          NETWORK_ADDRESS: 172.20.0.0
+          NETWORK_MASK: 255.255.255.0
+          GATEWAY: 172.20.0.1
+          DNS: 1.1.1.1
+
+frontend:
+  hosts:
+    f1: { ansible_host: 172.20.0.6 }
+
+node:
+  hosts:
+    n1: { ansible_host: 172.20.0.7 }
+    n2: { ansible_host: 172.20.0.8 }
+
+ceph:
+  children:
+    ? mons
+    ? mgrs
+    ? osds
+  vars: {}
+
+mons:
+  hosts:
+    mon1: { ansible_host: 172.20.0.6, monitor_address: 172.20.0.6 }
+
+mgrs:
+  hosts:
+    mgr1: { ansible_host: 172.20.0.6 }
+
+osds:
+  hosts:
+    osd1: { ansible_host: 172.20.0.10 }
+    osd2: { ansible_host: 172.20.0.11 }
+    osd3: { ansible_host: 172.20.0.12 }

--- a/inventory/group_vars/ceph.yml
+++ b/inventory/group_vars/ceph.yml
@@ -1,0 +1,4 @@
+---
+ceph_origin: distro
+configure_firewall: false
+no_log_on_ceph_key_tasks: false

--- a/inventory/group_vars/osds.yml
+++ b/inventory/group_vars/osds.yml
@@ -1,0 +1,2 @@
+---
+osd_auto_discovery: true

--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -1,0 +1,42 @@
+---
+- hosts:
+    - "{{ mon_group_name | d('mons') }}"
+    - "{{ mgr_group_name | d('mgrs') }}"
+    - "{{ osd_group_name | d('osds') }}"
+  collections:
+    - opennebula.deploy
+  roles:
+    - role: helper/facts
+      facts_subset: ['all', '!facter', '!ohai']
+      tags: [always]
+
+- hosts: "{{ mon_group_name | d('mons') }}"
+  roles:
+    - role: ceph-defaults
+    - role: ceph-facts
+    - role: ceph-handler
+    - role: ceph-common
+    - role: ceph-config
+    - role: ceph-mon
+
+- hosts: "{{ mgr_group_name | d('mgrs') }}"
+  roles:
+    - role: ceph-defaults
+    - role: ceph-common
+    - role: ceph-config
+    - role: ceph-mgr
+
+- hosts: "{{ osd_group_name | d('osds') }}"
+  roles:
+    - role: ceph-defaults
+    - role: ceph-facts
+    - role: ceph-handler
+    - role: ceph-common
+    - role: ceph-config
+    - role: ceph-osd
+
+- hosts: "{{ mon_group_name | d('mons') }}"
+  collections:
+    - opennebula.deploy
+  roles:
+    - role: ceph/mon

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -39,13 +39,18 @@
     - role: repository
       tags: [preinstall, prometheus]
 
+    - role: kvm
+
+    - role: ceph/node
+      tags: [ceph]
+      when:
+        - features.ceph | bool is true
+
     - role: datastore/node
       tags: [datastore]
 
     - role: network/node
       tags: [network]
-
-    - role: kvm
 
     - role: gate/proxy
       tags: [gate]
@@ -65,6 +70,11 @@
   roles:
     - role: helper/facts
       tags: [always]
+
+    - role: ceph/frontend
+      tags: [ceph]
+      when:
+        - features.ceph | bool is true
 
     - role: datastore/frontend
       tags: [datastore]

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,11 @@
 ---
+# NOTE: These are cummulative requirements for both one-deploy and ceph-ansible.
 collections:
-  - name: ansible.posix
+  - name: https://opendev.org/openstack/ansible-config_template
+    version: 1.2.1
+    type: git
   - name: ansible.utils
+    version: '>=2.5.0'
+  - name: ansible.posix
   - name: community.crypto
+  - name: community.general

--- a/roles/ceph/frontend/README.md
+++ b/roles/ceph/frontend/README.md
@@ -1,0 +1,38 @@
+Role: opennebula.deploy.ceph.frontend
+=====================================
+
+A role that manages Ceph related settings on an OpenNebula Frontend.
+
+Requirements
+------------
+
+N/A
+
+Role Variables
+--------------
+
+| Name         | Type   | Default   | Example                                | Description                                             |
+|--------------|--------|-----------|----------------------------------------|---------------------------------------------------------|
+| `ceph.uuid`  | `str`  | `null`    | `fd083b60-82ce-518b-a1a7-fc7bda472338` | UUID of the secret that is to keep Ceph key in Libvirt. |
+| `node_group` | `str`  | `node`    |                                        | Custom name of the Node group in the inventory.         |
+
+Dependencies
+------------
+
+Example Playbook
+----------------
+
+    - hosts: frontend
+      roles:
+        - role: opennebula.deploy.helper.facts
+        - role: opennebula.deploy.ceph.frontend
+
+License
+-------
+
+Apache-2.0
+
+Author Information
+------------------
+
+[OpenNebula Systems](https://opennebula.io/)

--- a/roles/ceph/frontend/meta/main.yml
+++ b/roles/ceph/frontend/meta/main.yml
@@ -1,0 +1,6 @@
+---
+collections:
+  - opennebula.deploy
+
+dependencies:
+  - role: opennebula.deploy.common

--- a/roles/ceph/frontend/tasks/main.yml
+++ b/roles/ceph/frontend/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- when: ceph.uuid is falsy
+  delegate_to: "{{ groups[node_group | d('node')][0] }}"
+  block:
+    - name: Slurp UUID
+      ansible.builtin.slurp:
+        path: "/etc/ceph/client.{{ ceph.user }}.secret.uuid"
+      register: slurp
+      ignore_errors: true
+
+    - name: Detect UUID
+      ansible.builtin.set_fact:
+        ceph: >-
+          {{ ceph | d({}) | combine(_update, recursive=true) }}
+      vars:
+        _update:
+          uuid: >-
+            {{ (_slurp[0].content | b64decode) if _slurp is truthy else None }}
+        _slurp: >-
+          {{ play_hosts | map('extract', hostvars, ['slurp']) | selectattr('failed', 'false') | list }}
+      run_once: true

--- a/roles/ceph/mon/README.md
+++ b/roles/ceph/mon/README.md
@@ -1,0 +1,37 @@
+Role: opennebula.deploy.ceph.mon
+================================
+
+A role that manages OpenNebula related settings on a Ceph mon.
+
+Requirements
+------------
+
+N/A
+
+Role Variables
+--------------
+
+| Name | Type | Default | Example | Description |
+|------|------|---------|---------|-------------|
+|      |      |         |         |             |
+
+Dependencies
+------------
+
+Example Playbook
+----------------
+
+    - hosts: mons
+      roles:
+        - role: opennebula.deploy.helper.facts
+        - role: opennebula.deploy.ceph.mon
+
+License
+-------
+
+Apache-2.0
+
+Author Information
+------------------
+
+[OpenNebula Systems](https://opennebula.io/)

--- a/roles/ceph/mon/meta/main.yml
+++ b/roles/ceph/mon/meta/main.yml
@@ -1,0 +1,6 @@
+---
+collections:
+  - opennebula.deploy
+
+dependencies:
+  - role: opennebula.deploy.common

--- a/roles/ceph/mon/tasks/main.yml
+++ b/roles/ceph/mon/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Install extra Ceph dependencies
+  ansible.builtin.package:
+    name: "{{ _common + _specific[ansible_os_family] }}"
+  vars:
+    _common: []
+    _specific:
+      Debian: [qemu-utils]
+      RedHat: [qemu-img]
+  register: package
+  until: package is success
+  retries: 12
+  delay: 5
+  tags: [package-install]

--- a/roles/ceph/node/README.md
+++ b/roles/ceph/node/README.md
@@ -1,0 +1,40 @@
+Role: opennebula.deploy.ceph.node
+=================================
+
+A role that manages Ceph related settings on an OpenNebula Node.
+
+Requirements
+------------
+
+N/A
+
+Role Variables
+--------------
+
+| Name             | Type   | Default   | Example                                | Description                                                |
+|------------------|--------|-----------|----------------------------------------|------------------------------------------------------------|
+| `ceph.pool`      | `str`  | `one`     |                                        | Name of the Ceph pool dedicated to OpenNebula.             |
+| `ceph.user`      | `str`  | `libvirt` |                                        | Ceph user that is to have access to the OpenNebula's pool. |
+| `ceph.uuid`      | `str`  | `null`    | `fd083b60-82ce-518b-a1a7-fc7bda472338` | UUID of the secret that is to keep Ceph key in Libvirt.    |
+| `mon_group_name` | `str`  | `mons`    |                                        | Name of the inventory group keeping all Ceph mons.         |
+
+Dependencies
+------------
+
+Example Playbook
+----------------
+
+    - hosts: node
+      roles:
+        - role: opennebula.deploy.helper.facts
+        - role: opennebula.deploy.ceph.node
+
+License
+-------
+
+Apache-2.0
+
+Author Information
+------------------
+
+[OpenNebula Systems](https://opennebula.io/)

--- a/roles/ceph/node/meta/main.yml
+++ b/roles/ceph/node/meta/main.yml
@@ -1,0 +1,6 @@
+---
+collections:
+  - opennebula.deploy
+
+dependencies:
+  - role: opennebula.deploy.common

--- a/roles/ceph/node/tasks/main.yml
+++ b/roles/ceph/node/tasks/main.yml
@@ -1,0 +1,185 @@
+---
+- name: Install extra Ceph dependencies
+  ansible.builtin.package:
+    name: "{{ _common + _specific[ansible_os_family] }}"
+  vars:
+    _common: [ceph-common]
+    _specific:
+      Debian: [qemu-utils]
+      RedHat: [qemu-img]
+  register: package
+  until: package is success
+  retries: 12
+  delay: 5
+  tags: [preinstall]
+
+- name: Create /var/run/ceph/ with correct permissions
+  ansible.builtin.file:
+    path: /var/run/ceph/
+    state: directory
+    owner: oneadmin
+    group: oneadmin
+    mode: u=rwx,go=rx
+
+- delegate_to: "{{ groups[mon_group_name | d('mons')][0] }}"
+  run_once: true
+  block:
+    - name: Ensure pool exists
+      ansible.builtin.shell:
+        cmd: |
+          set -o errexit
+
+          if ceph osd pool get '{{ ceph.pool }}' all; then exit 0; fi
+
+          ceph osd pool create '{{ ceph.pool }}' 128
+
+          exit 78
+        executable: /bin/bash
+      register: shell
+      changed_when:
+        - shell.rc == 78 # EREMCHG "Remote address changed" 8^)
+      failed_when:
+        - shell.rc != 0 and shell.rc != 78
+
+    - name: Ensure user exists
+      ansible.builtin.shell:
+        cmd: |
+          set -o errexit
+
+          if ceph auth get 'client.{{ ceph.user }}'; then exit 0; fi
+
+          ceph auth add 'client.{{ ceph.user }}' mon 'profile rbd' osd 'profile rbd pool={{ ceph.pool }}'
+
+          exit 78
+        executable: /bin/bash
+      register: shell
+      changed_when:
+        - shell.rc == 78 # EREMCHG "Remote address changed" 8^)
+      failed_when:
+        - shell.rc != 0 and shell.rc != 78
+
+- when: ceph.uuid is falsy
+  block:
+    - name: Slurp UUID
+      ansible.builtin.slurp:
+        path: "/etc/ceph/client.{{ ceph.user }}.secret.uuid"
+      register: slurp
+      ignore_errors: true
+
+    - name: Detect UUID
+      ansible.builtin.set_fact:
+        ceph: >-
+          {{ ceph | d({}) | combine(_update, recursive=true) }}
+      vars:
+        _update:
+          uuid: >-
+            {{ (_slurp[0].content | b64decode) if _slurp is truthy else None }}
+        _slurp: >-
+          {{ play_hosts | map('extract', hostvars, ['slurp']) | selectattr('failed', 'false') | list }}
+      run_once: true
+
+- when: ceph.uuid is falsy
+  block:
+    - name: Generate new UUID
+      ansible.builtin.set_fact:
+        new_uuid: >-
+          {{ lookup('password', '/dev/null chars=ascii_letters,digits length=32') | to_uuid }}
+      run_once: true
+
+    - name: Store UUID
+      ansible.builtin.copy:
+        dest: "/etc/ceph/client.{{ ceph.user }}.secret.uuid"
+        owner: oneadmin
+        group: oneadmin
+        mode: u=rw,g=r,o=
+        force: false
+        content: "{{ new_uuid }}"
+
+    - name: Set ceph.uuid fact
+      ansible.builtin.set_fact:
+        ceph: >-
+          {{ ceph | d({}) | combine(_update, recursive=true) }}
+      vars:
+        _update:
+          uuid: >-
+            {{ new_uuid }}
+      run_once: true
+
+- delegate_to: "{{ groups[mon_group_name | d('mons')][0] }}"
+  run_once: true
+  block:
+    - name: Get keyring
+      ansible.builtin.shell:
+        cmd: ceph auth get 'client.{{ ceph.user }}'
+        executable: /bin/bash
+      register: shell_keyring
+      changed_when: false
+
+    - name: Get key
+      ansible.builtin.shell:
+        cmd: ceph auth get-key 'client.{{ ceph.user }}'
+        executable: /bin/bash
+      register: shell_key
+      changed_when: false
+
+- name: Store keyring
+  ansible.builtin.copy:
+    dest: "/etc/ceph/ceph.client.{{ ceph.user }}.keyring"
+    owner: oneadmin
+    group: oneadmin
+    mode: u=rw,g=r,o=
+    content: |
+      {{ shell_keyring.stdout | trim }}
+
+- name: Create /etc/ceph/ceph.conf
+  ansible.builtin.copy:
+    dest: /etc/ceph/ceph.conf
+    owner: oneadmin
+    group: oneadmin
+    mode: u=rw,g=r,o=
+    content: |
+      [client.{{ ceph.user }}]
+      log file = /var/log/ceph/qemu-guest-$pid.log
+      admin socket = /var/run/ceph/$cluster-$type.$id.$pid.$cctid.asok
+      [global]
+      rbd_default_format = 2
+      mon host = {{ _mons }}
+  vars:
+    _hosts: >-
+      {{ groups[mon_group_name | d('mons')] | map('extract', hostvars, ['ansible_host']) | list }}
+    _mons: >-
+      {%- set output = [] -%}
+      {%- for host in _hosts -%}
+      {{- output.append( '[v2:%(host)s:3300,v1:%(host)s:6789]' | format(host=host) ) -}}
+      {%- endfor -%}
+      {{- output | join(_sep) -}}
+    _sep: ','
+
+- name: Create Libvirt secret XML
+  ansible.builtin.copy:
+    dest: "/etc/ceph/client.{{ ceph.user }}.secret.xml"
+    owner: oneadmin
+    group: oneadmin
+    mode: u=rw,g=r,o=
+    content: |
+      <secret ephemeral='no' private='no'>
+        <uuid>{{ ceph.uuid }}</uuid>
+        <usage type='ceph'>
+          <name>client.{{ ceph.user }} secret</name>
+        </usage>
+      </secret>
+
+- name: Create Ceph secret in Libvirt
+  ansible.builtin.shell:
+    cmd: |
+      set -o errexit
+      if ! virsh -c 'qemu:///system' secret-dumpxml '{{ ceph.uuid }}'; then
+        virsh -c 'qemu:///system' secret-define \
+        '/etc/ceph/client.{{ ceph.user }}.secret.xml'
+        virsh -c 'qemu:///system' secret-set-value \
+        --secret '{{ ceph.uuid }}' \
+        --base64 '{{ shell_key.stdout | trim }}'
+      fi
+    executable: /bin/bash
+  become_user: oneadmin
+  changed_when: false

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -3,6 +3,16 @@ features_defaults:
   gateproxy: false
   prometheus: false
   passenger: false
+  ceph: false
+
+ceph_defaults:
+  pool: one
+  user: libvirt
+  host: >-
+    {{ groups[mon_group_name | d('mons')] | map('extract', hostvars, ['ansible_host']) | join(d = ' ')
+       if groups[mon_group_name | d('mons')] is defined else
+       [] }}
+  uuid: null
 
 # We define it here, because it's used in both opennebula/* and gate/* roles.
 gate_endpoint: >-

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -3,3 +3,9 @@
   ansible.builtin.set_fact:
     features: >-
       {{ features_defaults | combine(features | d({})) }}
+
+- name: Compute facts (Ceph)
+  ansible.builtin.set_fact:
+    ceph: >-
+      {{ ceph_defaults | combine(ceph | d({})) }}
+  when: features.ceph | bool is true

--- a/roles/datastore/frontend/README.md
+++ b/roles/datastore/frontend/README.md
@@ -11,12 +11,12 @@ N/A
 Role Variables
 --------------
 
-| Name         | Type   | Default   | Example       | Description                                                            |
-|--------------|--------|-----------|---------------|------------------------------------------------------------------------|
-| `ds.mode`    | `str`  | `ssh`     |               | OpenNebula Datastore configuration mode: `ssh`, `shared` or `generic`. |
-| `ds.config`  | `dict` | `{}`      | (check below) | OpenNebula Datastore configuration for a specifc mode.                 |
-| `node_group` | `str`  | `node`    |               | Custom name of the Node group in the inventory.                        |
-| `leader`     | `str`  | undefined | `10.11.12.13` | When OpenNebula is in HA mode it points to the Leader.                 |
+| Name         | Type   | Default   | Example       | Description                                                                    |
+|--------------|--------|-----------|---------------|--------------------------------------------------------------------------------|
+| `ds.mode`    | `str`  | `ssh`     |               | OpenNebula Datastore configuration mode: `ssh`, `shared`, `ceph` or `generic`. |
+| `ds.config`  | `dict` | `{}`      | (check below) | OpenNebula Datastore configuration for a specifc mode.                         |
+| `node_group` | `str`  | `node`    |               | Custom name of the Node group in the inventory.                                |
+| `leader`     | `str`  | undefined | `10.11.12.13` | When OpenNebula is in HA mode it points to the Leader.                         |
 
 Dependencies
 ------------

--- a/roles/datastore/frontend/tasks/main.yml
+++ b/roles/datastore/frontend/tasks/main.yml
@@ -6,6 +6,7 @@
   vars:
     _mode_to_role:
       ssh: simple
+      ceph: simple
       shared: simple
       generic: generic
   when:

--- a/roles/datastore/generic/README.md
+++ b/roles/datastore/generic/README.md
@@ -11,13 +11,17 @@ N/A
 Role Variables
 --------------
 
-| Name          | Type   | Default   | Example       | Description                                                            |
-|---------------|--------|-----------|---------------|------------------------------------------------------------------------|
-| `ds.mode`     | `str`  | `ssh`     |               | OpenNebula Datastore configuration mode: `ssh`, `shared` or `generic`. |
-| `ds.config`   | `dict` | `{}`      | (check below) | OpenNebula Datastore configuration for a specifc mode.                 |
-| `ds_defaults` | `dict` |           |               | Defaults that are merged with user configs.                            |
-| `node_group`  | `str`  | `node`    |               | Custom name of the Node group in the inventory.                        |
-| `leader`      | `str`  | undefined | `10.11.12.13` | When OpenNebula is in HA mode it points to the Leader.                 |
+| Name          | Type   | Default   | Example                                | Description                                                                    |
+|---------------|--------|-----------|----------------------------------------|--------------------------------------------------------------------------------|
+| `ds.mode`     | `str`  | `ssh`     |                                        | OpenNebula Datastore configuration mode: `ssh`, `shared`, `ceph` or `generic`. |
+| `ds.config`   | `dict` | `{}`      | (check below)                          | OpenNebula Datastore configuration for a specifc mode.                         |
+| `ds_defaults` | `dict` |           |                                        | Defaults that are merged with user configs.                                    |
+| `ceph.pool`   | `str`  | `one`     |                                        | Name of the Ceph pool dedicated to OpenNebula.                                 |
+| `ceph.user`   | `str`  | `libvirt` |                                        | Ceph user that is to have access to the OpenNebula's pool.                     |
+| `ceph.host`   | `str`  |           | `10.11.12.13 10.11.12.14:1234`         | Space-separated list of IP:PORT pairs of Ceph mons.                            |
+| `ceph.uuid`   | `str`  | `null`    | `fd083b60-82ce-518b-a1a7-fc7bda472338` | UUID of the secret that is to keep Ceph key in Libvirt.                        |
+| `node_group`  | `str`  | `node`    |                                        | Custom name of the Node group in the inventory.                                |
+| `leader`      | `str`  | undefined | `10.11.12.13`                          | When OpenNebula is in HA mode it points to the Leader.                         |
 
 Dependencies
 ------------

--- a/roles/datastore/node/tasks/main.yml
+++ b/roles/datastore/node/tasks/main.yml
@@ -6,6 +6,7 @@
   vars:
     _mode_to_role:
       ssh: simple
+      ceph: simple
       shared: simple
       generic: generic
   when:

--- a/roles/datastore/simple/README.md
+++ b/roles/datastore/simple/README.md
@@ -1,7 +1,7 @@
 Role: opennebula.deploy.datastore.simple
 ========================================
 
-A role that manages OpenNebula datastores (`ssh` and `shared` modes).
+A role that manages OpenNebula datastores (`ssh`, `ceph` and `shared` modes).
 
 Requirements
 ------------
@@ -11,13 +11,17 @@ N/A
 Role Variables
 --------------
 
-| Name          | Type   | Default   | Example       | Description                                                            |
-|---------------|--------|-----------|---------------|------------------------------------------------------------------------|
-| `ds.mode`     | `str`  | `ssh`     |               | OpenNebula Datastore configuration mode: `ssh`, `shared` or `generic`. |
-| `ds.config`   | `dict` | `{}`      | (check below) | OpenNebula Datastore configuration for a specifc mode.                 |
-| `ds_defaults` | `dict` |           |               | Defaults that are merged with user configs.                            |
-| `node_group`  | `str`  | `node`    |               | Custom name of the Node group in the inventory.                        |
-| `leader`      | `str`  | undefined | `10.11.12.13` | When OpenNebula is in HA mode it points to the Leader.                 |
+| Name          | Type   | Default   | Example                                | Description                                                                    |
+|---------------|--------|-----------|----------------------------------------|--------------------------------------------------------------------------------|
+| `ds.mode`     | `str`  | `ssh`     |                                        | OpenNebula Datastore configuration mode: `ssh`, `ceph`, `shared` or `generic`. |
+| `ds.config`   | `dict` | `{}`      | (check below)                          | OpenNebula Datastore configuration for a specifc mode.                         |
+| `ds_defaults` | `dict` |           |                                        | Defaults that are merged with user configs.                                    |
+| `ceph.pool`   | `str`  | `one`     |                                        | Name of the Ceph pool dedicated to OpenNebula.                                 |
+| `ceph.user`   | `str`  | `libvirt` |                                        | Ceph user that is to have access to the OpenNebula's pool.                     |
+| `ceph.host`   | `str`  |           | `10.11.12.13 10.11.12.14:1234`         | Space-separated list of IP:PORT pairs of Ceph mons.                            |
+| `ceph.uuid`   | `str`  | `null`    | `fd083b60-82ce-518b-a1a7-fc7bda472338` | UUID of the secret that is to keep Ceph key in Libvirt.                        |
+| `node_group`  | `str`  | `node`    |                                        | Custom name of the Node group in the inventory.                                |
+| `leader`      | `str`  | undefined | `10.11.12.13`                          | When OpenNebula is in HA mode it points to the Leader.                         |
 
 Dependencies
 ------------

--- a/roles/datastore/simple/defaults/main.yml
+++ b/roles/datastore/simple/defaults/main.yml
@@ -14,6 +14,28 @@ ds_defaults:
     FILE_DS:
       template:
         TM_MAD: ssh
+  ceph:
+    SYSTEM_DS:
+      template:
+        TM_MAD: ceph
+        POOL_NAME: "{{ ceph.pool }}"
+        CEPH_HOST: "{{ ceph.host }}"
+        CEPH_USER: "{{ ceph.user }}"
+        CEPH_SECRET: "{{ ceph.uuid }}"
+        BRIDGE_LIST: "{{ groups[node_group | d('node')] | map('extract', hostvars, ['ansible_host']) | join(' ') }}"
+    IMAGE_DS:
+      template:
+        TM_MAD: ceph
+        DS_MAD: ceph
+        DISK_TYPE: RBD
+        POOL_NAME: "{{ ceph.pool }}"
+        CEPH_HOST: "{{ ceph.host }}"
+        CEPH_USER: "{{ ceph.user }}"
+        CEPH_SECRET: "{{ ceph.uuid }}"
+        BRIDGE_LIST: "{{ groups[node_group | d('node')] | map('extract', hostvars, ['ansible_host']) | join(' ') }}"
+    FILE_DS:
+      template:
+        TM_MAD: ssh
   shared:
     SYSTEM_DS:
       template:

--- a/roles/precheck/tasks/main.yml
+++ b/roles/precheck/tasks/main.yml
@@ -69,3 +69,18 @@
     _supported:
       - kvm
       - qemu
+
+- name: Check if Ceph feature is supported for current distro family
+  ansible.builtin.assert:
+    that: (features.ceph | bool is false)
+          or
+          (inventory_hostname not in _hosts)
+          or
+          (ansible_os_family in _supported)
+    msg: Please use one of the supported linux distro families {{ _supported }} to run Ceph.
+  vars:
+    _supported:
+      - Debian
+    _tmp:
+      - "{{ groups[node_group | d('node')] if groups[node_group | d('node')] is defined else [] }}"
+    _hosts: "{{ _tmp | flatten | unique }}"


### PR DESCRIPTION
- Add features.ceph flag
- Add ceph-ansible submodule in the vendor/ subdirectory
- Merge requirements from one-deploy and ceph-ansible projects
- Add ceph.yml playbook for Ceph cluster deployment (uses roles from ceph-ansible)
- Add ceph/* roles for datastore management in OpenNebula
- Add example ceph.yml inventory
- Update docs