### PR TITLE
B #-: Guard datastore defaults + readme update (fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The documentation is organized based on three distinct architectures. We will st
 * Deployments
     * [Local storage](../../wiki/arch_single_local)
     * [Shared storage](../../wiki/arch_single_shared)
+    * [Ceph storage](../../wiki/arch_single_ceph)
     * [High availability front-ends](../../wiki/arch_ha)
     * [Connect through a bastion host](../../wiki/arch_bastion)
     * [Other configurations](../../wiki/arch_other)

--- a/roles/datastore/simple/defaults/main.yml
+++ b/roles/datastore/simple/defaults/main.yml
@@ -18,20 +18,20 @@ ds_defaults:
     SYSTEM_DS:
       template:
         TM_MAD: ceph
-        POOL_NAME: "{{ ceph.pool }}"
-        CEPH_HOST: "{{ ceph.host }}"
-        CEPH_USER: "{{ ceph.user }}"
-        CEPH_SECRET: "{{ ceph.uuid }}"
+        POOL_NAME: "{{ ceph.pool if features.ceph is true else None }}"
+        CEPH_HOST: "{{ ceph.host if features.ceph is true else None }}"
+        CEPH_USER: "{{ ceph.user if features.ceph is true else None }}"
+        CEPH_SECRET: "{{ ceph.uuid if features.ceph is true else None }}"
         BRIDGE_LIST: "{{ groups[node_group | d('node')] | map('extract', hostvars, ['ansible_host']) | join(' ') }}"
     IMAGE_DS:
       template:
         TM_MAD: ceph
         DS_MAD: ceph
         DISK_TYPE: RBD
-        POOL_NAME: "{{ ceph.pool }}"
-        CEPH_HOST: "{{ ceph.host }}"
-        CEPH_USER: "{{ ceph.user }}"
-        CEPH_SECRET: "{{ ceph.uuid }}"
+        POOL_NAME: "{{ ceph.pool if features.ceph is true else None }}"
+        CEPH_HOST: "{{ ceph.host if features.ceph is true else None }}"
+        CEPH_USER: "{{ ceph.user if features.ceph is true else None }}"
+        CEPH_SECRET: "{{ ceph.uuid if features.ceph is true else None }}"
         BRIDGE_LIST: "{{ groups[node_group | d('node')] | map('extract', hostvars, ['ansible_host']) | join(' ') }}"
     FILE_DS:
       template:


### PR DESCRIPTION
- With Ceph feature disabled datastore/simple role was causing playbook crash due to undefined ceph.* facts
- Link to the Ceph datastore documentation in the wiki was missing from the main readme