### PR TITLE
dev-on-laptop: fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ infra pre ceph site main:
 requirements: requirements-python requirements-galaxy
 
 requirements-python: $(SELF)/requirements.txt
-	pip3 install --requirement $<
+	pip3 install --requirement $< 2> /dev/null || pip3 install --break-system-packages --requirement $<
 
 requirements-galaxy: $(SELF)/requirements.yml
 	ansible-galaxy collection install --requirements-file $<

--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -11,7 +11,7 @@
       Debian:
         MariaDB: [mariadb-server]
         PostgreSQL: [postgresql]
-        SQLite: [sqlite]
+        SQLite: [sqlite3]
       RedHat:
         MariaDB: [mariadb-server]
         PostgreSQL: [postgresql-server]


### PR DESCRIPTION
- Add support for systems implementing PEP 668 (e.g., newer Ubuntus) which require that the --break-system-packages flag gets passed to pip whenever installing packages outside virtualenvs.
- (Debian+Ubuntu) Install the sqlite3 package instead of sqlite, which is required on recent releases:
```
                     | sqlite | sqlite3 |
  Ubuntu 20.04       |      X |       X |
  Ubuntu 22.04       |      X |       X |
  Ubuntu 23.04+      |        |       X |
  Debian 10 Buster   |      X |       X |
  Debian 11 Bullseye |        |       X |
  Debian 12 Bookworm |        |       X |
  Debian 13 Trixie+  |        |       X |
```