### PR TITLE
B #62: Replace set operations with deterministic equivalents

### DIFF
--- a/roles/datastore/generic/tasks/frontend.yml
+++ b/roles/datastore/generic/tasks/frontend.yml
@@ -54,7 +54,7 @@
       loop: "{{ _existing }}"
       vars:
         _existing: >-
-          {{ ds_names | intersect(ds_names_parsed) | list }}
+          {{ ds_names | select('in', ds_names_parsed) }}
         _combined: >-
           {{ ds_dict_parsed[item].TEMPLATE | combine(ds_dict[item].template, recursive=true) }}
 
@@ -73,4 +73,4 @@
       loop: "{{ _missing }}"
       vars:
         _missing: >-
-          {{ ds_names | difference(ds_names_parsed) | list }}
+          {{ ds_names | reject('in', ds_names_parsed) }}

--- a/roles/infra/tasks/main.yml
+++ b/roles/infra/tasks/main.yml
@@ -39,7 +39,7 @@
       {{ dict(_frontends | zip(_frontends | map('extract', hostvars, ['infra_hostname']))) }}
     # NOTE: We deliberately remove existing (defined) VMs as we don't touch them ever again (unless undefined)!
     _frontends: >-
-      {{ groups[_frontend_group] | difference(defined_vms.list_vms) }}
+      {{ groups[_frontend_group] | reject('in', defined_vms.list_vms) }}
     _frontend_group: >-
       {{ frontend_group | d('frontend') }}
 

--- a/roles/network/frontend/tasks/main.yml
+++ b/roles/network/frontend/tasks/main.yml
@@ -69,7 +69,7 @@
         _name_to_template: >-
           {{ dict(vn_names_parsed | zip(vn_templates_parsed)) }}
         _existing: >-
-          {{ vn_names | intersect(vn_names_parsed) | list }}
+          {{ vn_names | select('in', vn_names_parsed) }}
         _combined: >-
           {{ _name_to_template[item] | combine(vn_dict[item].template, recursive=true) }}
 
@@ -88,7 +88,7 @@
       loop: "{{ _missing }}"
       vars:
         _missing: >-
-          {{ vn_names | difference(vn_names_parsed) | list }}
+          {{ vn_names | reject('in', vn_names_parsed) }}
 
     - name: Update ARs
       ansible.builtin.shell:
@@ -108,7 +108,7 @@
       loop: "{{ _existing }}"
       vars:
         _existing: >-
-          {{ ar_keys | intersect(ar_keys_parsed) | list }}
+          {{ ar_keys | select('in', ar_keys_parsed) }}
         _combined: >-
           {{ ar_dict_parsed[item.0][item.1] | combine(ar_dict[item.0][item.1], recursive=true) }}
 
@@ -127,4 +127,4 @@
       loop: "{{ _missing }}"
       vars:
         _missing: >-
-          {{ ar_keys | difference(ar_keys_parsed) | list }}
+          {{ ar_keys | reject('in', ar_keys_parsed) }}

--- a/roles/network/node/tasks/networkmanager.yml
+++ b/roles/network/node/tasks/networkmanager.yml
@@ -15,7 +15,7 @@
         _active: >-
           {{ dict(shell.stdout_lines | map('split', _sep)) }}
         _selected: >-
-          {{ _active.keys() | intersect([_phydev, _bridge]) }}
+          {{ _active.keys() | select('in', [_phydev, _bridge]) }}
         _sep: ':'
 
     - name: Map CON -> KV (get)

--- a/roles/opennebula/server/tasks/ha.yml
+++ b/roles/opennebula/server/tasks/ha.yml
@@ -17,7 +17,7 @@
     oned_no_restart: >-
       {{ federation.groups.frontend
          if _running is falsy else
-         federation.groups.frontend | difference(_peer_names) }}
+         federation.groups.frontend | reject('in', _peer_names) }}
   vars:
     # We process shell results from all Front-ends at once.
     _results: >-
@@ -52,5 +52,5 @@
   loop_control: { loop_var: follower }
   vars:
     _followers: >-
-      {{ federation.groups.frontend | difference([leader]) }}
+      {{ federation.groups.frontend | reject('in', [leader]) }}
   when: inventory_hostname == leader

--- a/roles/opennebula/server/tasks/sync_ha.yml
+++ b/roles/opennebula/server/tasks/sync_ha.yml
@@ -68,7 +68,7 @@
       {{ _followers | map('extract', hostvars, ['db_ok']) is all }}
   vars:
     _followers: >-
-      {{ federation.groups.frontend | difference([leader]) }}
+      {{ federation.groups.frontend | reject('in', [leader]) }}
   when: inventory_hostname == leader
 
 - when:

--- a/roles/prometheus/server/tasks/alertmanager.yml
+++ b/roles/prometheus/server/tasks/alertmanager.yml
@@ -28,7 +28,7 @@
         # NOTE: Providing cluster peers from the command line seems to be
         # the only supported way to configure HA Alertmanager.
         _peers: >-
-          {{ ansible_play_hosts_all | difference([inventory_hostname])
+          {{ ansible_play_hosts_all | reject('in', [inventory_hostname])
                                     | map('regex_replace', '^(.*)$', ' --cluster.peer=\g<1>:9094 ')
                                     | join }}
       register: copy_override_conf


### PR DESCRIPTION
It seems since ansible-core>=2.16.0, set operations like intersect or difference may produce randomly reordered arrays.