### PR TITLE
M #: Disable automatic updates on deb based systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ __pycache__/
 !/inventory/evpn-ha.yml
 /.env.yml
 /poetry.lock
+.vscode

--- a/roles/helper/cache/README.md
+++ b/roles/helper/cache/README.md
@@ -11,9 +11,10 @@ N/A
 Role Variables
 --------------
 
-| Name               | Type   | Default | Example | Description             |
-|--------------------|--------|---------|---------|-------------------------|
-| `update_pkg_cache` | `bool` | `false` | `true`  | Update APT / DNF cache. |
+| Name               | Type   | Default | Example | Description                            |
+|--------------------|--------|---------|---------|----------------------------------------|
+| `update_pkg_cache` | `bool` | `false` | `true`  | Update APT / DNF cache.                |
+| `unattend_disable` | `bool` | `false` | `true`  | Purges the unattended upgrade service  |
 
 Dependencies
 ------------
@@ -25,7 +26,7 @@ Example Playbook
 
     - hosts: frontend:node
       roles:
-        - { role: opennebula.deploy.helper.cache, update_pkg_cache: true }
+        - { role: opennebula.deploy.helper.cache, update_pkg_cache: true, unattend_disable: true }
 
 License
 -------

--- a/roles/helper/cache/defaults/main.yml
+++ b/roles/helper/cache/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 update_pkg_cache: false
+unattend_disable: false

--- a/roles/helper/cache/tasks/main.yml
+++ b/roles/helper/cache/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: Purge unattended upgrade service
+  ansible.builtin.package:
+    name: unattended-upgrades
+    state: absent
+    purge: true
+  when:
+  - unattend_disable | bool is true
+  - ansible_os_family == "Debian"
+
 - name: Update package cache
   ansible.builtin.package:
     update_cache: true


### PR DESCRIPTION
- Remove automatic updates as this can cause errors when running other ansible tasks when installing packages due to the apt process lock
- ignore `.vscode` files on git