### PR TITLE
F #80: Add support for 6.10 / Ubuntu 24.04 + Debian 12

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -73,7 +73,6 @@
       tags: [prometheus]
       when: &prometheus
         - features.prometheus | bool is true
-        - one_token is defined and one_token is truthy
 
 - hosts: "{{ frontend_group | d('frontend') }}"
   tags: [frontend, stage3]

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -13,4 +13,4 @@ ceph_defaults:
        if groups[mon_group_name | d('mons')] is defined else
        [] }}
   uuid: null
-  repo: distro
+  repo: community

--- a/roles/opennebula/server/tasks/join.yml
+++ b/roles/opennebula/server/tasks/join.yml
@@ -29,6 +29,10 @@
           {{ [_server_pool.SERVER] | flatten | map(attribute='NAME') | list }}
         _this: >-
           {{ follower | d(inventory_hostname) }}
+      register: result
+      until: result is success
+      retries: 3
+      delay: 5
 
     - <<: *Get_Zone
 

--- a/roles/precheck/tasks/main.yml
+++ b/roles/precheck/tasks/main.yml
@@ -28,6 +28,8 @@
   ansible.builtin.assert:
     that: (features.prometheus | bool is false)
           or
+          (one_version is version('6.10', '>='))
+          or
           (one_token is defined and one_token is truthy)
     msg: Please either disable the Prometheus feature or provide one_token.
   run_once: true
@@ -108,9 +110,11 @@
       Debian:
         '10': []
         '11': [community]
+        '12': []
       Ubuntu:
         '20': [community]
         '22': [distro, community]
+        '24': []
       AlmaLinux:
         '8': [distro, community]
         '9': [community]

--- a/roles/repository/defaults/main.yml
+++ b/roles/repository/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-one_version: '6.8'
+one_version: '6.10'
 
 repo_constraints:
   ceph:


### PR DESCRIPTION
- Remove one_token requirement for Prometheus (>=6.10).
- Add retry loop for 'onezone server-add' to improve stability.
- Switch default Ceph repo type to 'community'.