### PR TITLE
M #-: Deprecate galaxy and poetry versioning (fix)

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: opennebula
 name: deploy
-version: 1.0.0
+version: 0.0.0
 
 readme: README.md
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "one-deploy"
-version = "1.0.0"
+version = "0.0.0"
 description = ""
 authors = ["OpenNebula <contact@opennebula.io>"]
 


### PR DESCRIPTION
- Version in pyproject.toml is insignificant to the project.
- Version in galaxy.yml can confuse users since any branch can be used to clone the collection (and we don't use Galaxy portal).