### PR TITLE
B #99: Correctly handle vault-encrypted values in inventory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ all: main
 infra pre ceph site main: _TAGS      := $(if $(TAGS),-t $(TAGS),)
 infra pre ceph site main: _SKIP_TAGS := $(if $(SKIP_TAGS),--skip-tags $(SKIP_TAGS),)
 infra pre ceph site main: _VERBOSE   := $(if $(VERBOSE),-$(VERBOSE),)
+infra pre ceph site main: _ASK_VAULT := $(if $(findstring $$ANSIBLE_VAULT;,$(file < $(INVENTORY))),--ask-vault-pass,)
 
 ifdef ENV_DEFAULT
 $(ENV_DEFAULT):
@@ -43,7 +44,7 @@ endif
 
 infra pre site main: $(ENV_DEFAULT)
 	cd $(SELF)/ && \
-	$(call ENV_RUN,default) ansible-playbook $(_VERBOSE) -i $(INVENTORY) $(_TAGS) $(_SKIP_TAGS) opennebula.deploy.$@
+	$(call ENV_RUN,default) ansible-playbook $(_VERBOSE) -i $(INVENTORY) $(_ASK_VAULT) $(_TAGS) $(_SKIP_TAGS) opennebula.deploy.$@
 
 ifdef ENV_CEPH
 $(ENV_CEPH):
@@ -52,7 +53,7 @@ endif
 
 ceph: $(ENV_CEPH)
 	cd $(SELF)/ && \
-	$(call ENV_RUN,ceph) ansible-playbook $(_VERBOSE) -i $(INVENTORY) $(_TAGS) $(_SKIP_TAGS) opennebula.deploy.$@
+	$(call ENV_RUN,ceph) ansible-playbook $(_VERBOSE) -i $(INVENTORY) $(_ASK_VAULT) $(_TAGS) $(_SKIP_TAGS) opennebula.deploy.$@
 
 .PHONY: requirements requirements-hatch requirements-python requirements-galaxy clean-requirements
 

--- a/roles/precheck/tasks/main.yml
+++ b/roles/precheck/tasks/main.yml
@@ -5,15 +5,18 @@
     msg: Please use ansible version >= 2.14.0.
   run_once: true
 
-- name: Ensure string type for critical vars
+- name: Ensure correct type for critical vars
   ansible.builtin.assert:
     that:
       - context.PASSWORD is undefined or context.PASSWORD is string
-      - one_pass is undefined or one_pass is none or one_pass is string
+                                      or context.PASSWORD | type_debug == 'AnsibleVaultEncryptedUnicode'
+      - one_pass is undefined or one_pass is string
+                              or one_pass | type_debug == 'AnsibleVaultEncryptedUnicode'
+                              or one_pass is none
       - one_token is undefined or one_token is string
+                               or one_token | type_debug == 'AnsibleVaultEncryptedUnicode'
       - one_version is string
     msg: Please make sure [context.PASSWORD, one_pass, one_token, one_version] are valid strings.
-  run_once: true
 
 - name: Validate passwords strength
   ansible.builtin.assert:
@@ -53,7 +56,6 @@
   when:
     - prod_env | d(false) | bool is true
     - _items[item].condition
-  run_once: true
 
 - name: Check if one_vip/force_ha settings are valid
   ansible.builtin.assert:


### PR DESCRIPTION
- Make sure precheck role doesn't fail
- Extend Makefile so it detects if --ask-vault-pass is required