### PR TITLE
B #104: One-deploy not configuring token_remote_support for FireEdge sunstone when EE token is provided

### DIFF
--- a/roles/gui/tasks/config.yml
+++ b/roles/gui/tasks/config.yml
@@ -7,8 +7,8 @@
 - name: Configure Sunstone Server (:token_remote_support)
   ansible.builtin.lineinfile:
     path: /etc/one/fireedge/sunstone/sunstone-server.conf
-    regexp: '^[#\s]*:token_remote_support:.*$'
-    line: ':token_remote_support: "{{ one_token }}"'
+    regexp: '^[#\s]*token_remote_support:.*$'
+    line: 'token_remote_support: "{{ one_token }}"'
   notify:
     - Restart FireEdge Server
   when: one_token is defined and one_token is truthy


### PR DESCRIPTION
- Update token_remote_support regex