### PR TITLE
F #127: Make pre-enabled DNF repos customizable

### DIFF
--- a/roles/repository/README.md
+++ b/roles/repository/README.md
@@ -40,6 +40,7 @@ Role Variables
 | `opennebula_repo_key_url`       | `dict` |               |                     | OpenNebula GPG key urls for Debian/RedHat distros.                    |
 | `opennebula_repo_path`          | `dict` |               |                     | OpenNebula repo definition paths for Debian/RedHat distros.           |
 | `opennebula_repo_url`           | `dict` |               | (check below)       | OpenNebula repo url for Debian/RedHat distros.                        |
+| `opennebula_repo_pre_enable`    | `dict` |               | (check below)       | Definition of DNF repos to pre-enable in RedHat-like distros.         |
 
 Dependencies
 ------------
@@ -55,6 +56,12 @@ Example Playbook
 
         # Enable OpenNebula EE repo.
         one_token: 'asd123as:123asd12'
+
+        # Enable only 'epel' and 'crb' DNF repos in Alma Linux 9
+        opennebula_repo_pre_enable:
+          AlmaLinux:
+            config_manager:
+              '9': [epel, crb]
 
         # Use custom / local / insecure OpenNebula repo.
         opennebula_repo_force_trusted: true

--- a/roles/repository/defaults/main.yml
+++ b/roles/repository/defaults/main.yml
@@ -142,3 +142,19 @@ opennebula_repo_url_defaults:
     {%- else -%}
       https://downloads.opennebula.io/repo/{{ one_version }}/{{ ansible_distribution }}/{{ ansible_distribution_version }}
     {%- endif -%}
+
+opennebula_repo_pre_enable:
+  AlmaLinux:
+    config_manager:
+      '8': [epel, powertools, ha]
+      '9': [epel, crb, highavailability]
+    subscription_manager:
+      '8': []
+      '9': []
+  RedHat:
+    config_manager:
+      '8': [epel]
+      '9': [epel]
+    subscription_manager:
+      '8': [codeready-builder-for-rhel-8-x86_64-rpms, rhel-8-for-x86_64-highavailability-rpms]
+      '9': [codeready-builder-for-rhel-9-x86_64-rpms, rhel-9-for-x86_64-highavailability-rpms]

--- a/roles/repository/defaults/main.yml
+++ b/roles/repository/defaults/main.yml
@@ -143,7 +143,7 @@ opennebula_repo_url_defaults:
       https://downloads.opennebula.io/repo/{{ one_version }}/{{ ansible_distribution }}/{{ ansible_distribution_version }}
     {%- endif -%}
 
-opennebula_repo_pre_enable:
+opennebula_repo_pre_enable_defaults:
   AlmaLinux:
     config_manager:
       '8': [epel, powertools, ha]

--- a/roles/repository/tasks/opennebula.yml
+++ b/roles/repository/tasks/opennebula.yml
@@ -7,19 +7,23 @@
           set -o errexit
 
           {% if _config_manager | count > 0 %}
-          dnf config-manager -y --enable {{ _config_manager | join(' ') }}
+          dnf config-manager -y --enable {{ _config_manager | map('regex_replace', '^(.*)$', "'\g<1>'") | join(' ') }}
           {% endif %}
 
           {% if _subscription_manager | count > 0 %}
-          subscription-manager repos {{ _subscription_manager | map('regex_replace', '^(.*)$', '--enable \g<1>') | join(' ') }}
+          subscription-manager repos {{ _subscription_manager | map('regex_replace', '^(.*)$', "--enable '\g<1>'") | join(' ') }}
           {% endif %}
         executable: /bin/bash
       changed_when: false
       vars:
         _config_manager: >-
-          {{ opennebula_repo_pre_enable[ansible_distribution].config_manager[ansible_distribution_major_version] | d([]) }}
+          {{ opennebula_repo_pre_enable[ansible_distribution].config_manager[ansible_distribution_major_version]
+             | d([])
+             | map('replace', "'", '') }}
         _subscription_manager: >-
-          {{ opennebula_repo_pre_enable[ansible_distribution].subscription_manager[ansible_distribution_major_version] | d([]) }}
+          {{ opennebula_repo_pre_enable[ansible_distribution].subscription_manager[ansible_distribution_major_version]
+             | d([])
+             | map('replace', "'", '') }}
 
 - vars:
     # Merge repository config with defaults.

--- a/roles/repository/tasks/opennebula.yml
+++ b/roles/repository/tasks/opennebula.yml
@@ -5,25 +5,21 @@
       ansible.builtin.shell:
         cmd: |
           set -o errexit
-          {{ _script[ansible_distribution][ansible_distribution_major_version] }}
+
+          {% if _config_manager | count > 0 %}
+          dnf config-manager -y --enable {{ _config_manager | join(' ') }}
+          {% endif %}
+
+          {% if _subscription_manager | count > 0 %}
+          subscription-manager repos {{ _subscription_manager | map('regex_replace', '^(.*)$', '--enable \g<1>') | join(' ') }}
+          {% endif %}
         executable: /bin/bash
       changed_when: false
       vars:
-        _script:
-          AlmaLinux:
-            '8': |
-              dnf config-manager -y --enable epel powertools ha
-            '9': |
-              dnf config-manager -y --enable epel crb highavailability
-          RedHat:
-            '8': |
-              dnf config-manager -y --enable epel
-              subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms \
-                                         --enable rhel-8-for-x86_64-highavailability-rpms
-            '9': |
-              dnf config-manager -y --enable epel
-              subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms \
-                                         --enable rhel-9-for-x86_64-highavailability-rpms
+        _config_manager: >-
+          {{ opennebula_repo_pre_enable[ansible_distribution].config_manager[ansible_distribution_major_version] | d([]) }}
+        _subscription_manager: >-
+          {{ opennebula_repo_pre_enable[ansible_distribution].subscription_manager[ansible_distribution_major_version] | d([]) }}
 
 - vars:
     # Merge repository config with defaults.

--- a/roles/repository/tasks/opennebula.yml
+++ b/roles/repository/tasks/opennebula.yml
@@ -1,6 +1,11 @@
 ---
 - when: ansible_pkg_mgr == 'dnf'
   block:
+    - name: Compute facts (DNF)
+      ansible.builtin.set_fact:
+        opennebula_repo_pre_enable: >-
+          {{ opennebula_repo_pre_enable_defaults | combine(opennebula_repo_pre_enable | d({}), recursive=true) }}
+
     - name: Enable required DNF extra repos
       ansible.builtin.shell:
         cmd: |


### PR DESCRIPTION
`inventory/test.yml`:
```yaml
all:
  vars:
    opennebula_repo_pre_enable:
      AlmaLinux:
        config_manager:
          '9': [epel, crb1234]
```

```shell
ansible-playbook -vv -i inventory/test.yml opennebula.deploy.main -e ansible_distribution=AlmaLinux
```