### PR TITLE
B #134: Include macaddress in netplan bridge

### DIFF
--- a/roles/network/node/tasks/netplan.yml
+++ b/roles/network/node/tasks/netplan.yml
@@ -41,6 +41,7 @@
           netplan set 'bridges.{{ _bridge }}.{{ key }}={{ value | to_json }}'
           {% endfor %}
           netplan set 'bridges.{{ _bridge }}.interfaces=["{{ _phydev }}"]'
+          netplan set 'bridges.{{ _bridge }}.macaddress={{ _macaddress }}'
 
           {% for key, value in _cleanup.items() %}
           netplan set '{{ phydev_cfg[_phydev].type }}.{{ _phydev }}.{{ key }}={{ value | to_json }}'
@@ -54,6 +55,8 @@
           {{ phydev_cfg[_phydev].config | dict2items
                                         | selectattr('key', 'in', _cleanup.keys())
                                         | items2dict }}
+        _macaddress: >-
+          {{ ansible_facts[_phydev]['macaddress'] }}
         _cleanup:
           dhcp4: false
           dhcp6: false


### PR DESCRIPTION
This PR adds the MAC address to the Netplan bridge configuration to avoid issues when using DHCP