### PR TITLE
M #-: Make one-deploy work with ansible-core 2.19+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ requirements-python: $(SELF)/requirements.txt
 	pip3 install --requirement $<
 
 requirements-galaxy: $(SELF)/requirements.yml $(ENV_DEFAULT)
-	$(call ENV_RUN,default) ansible-galaxy collection install --requirements-file $<
+	$(call ENV_RUN,default) ansible-galaxy collection install --requirements-file $< --collections-path $(SELF)/ansible_collections
 
 clean-requirements:
 	find $(SELF)/ansible_collections/ -mindepth 1 -maxdepth 1 -type d ! -name opennebula -exec rm -rf {} +

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,15 +7,15 @@ roles_path        = ./vendor/ceph-ansible/roles/
 library           = ./vendor/ceph-ansible/library/
 module_utils      = ./vendor/ceph-ansible/module_utils/
 
-inventory             = ./inventory/example.yml
-gathering             = explicit
-host_key_checking     = false
-display_skipped_hosts = true
-retry_files_enabled   = false
-any_errors_fatal      = true
-callbacks_enabled     = profile_tasks
-stdout_callback       = yaml
-timeout               = 30
+inventory              = ./inventory/example.yml
+gathering              = explicit
+host_key_checking      = false
+display_skipped_hosts  = true
+retry_files_enabled    = false
+any_errors_fatal       = true
+callbacks_enabled      = profile_tasks
+callback_result_format = yaml
+timeout                = 30
 
 [privilege_escalation]
 become      = true

--- a/molecule/ceph-hci/molecule.yml
+++ b/molecule/ceph-hci/molecule.yml
@@ -66,7 +66,7 @@ provisioner:
       retry_files_enabled: false
       any_errors_fatal: true
       callbacks_enabled: profile_tasks
-      stdout_callback: yaml
+      callback_result_format: yaml
     privilege_escalation:
       become: true
       become_user: root

--- a/molecule/federation-1st/molecule.yml
+++ b/molecule/federation-1st/molecule.yml
@@ -52,7 +52,7 @@ provisioner:
       retry_files_enabled: false
       any_errors_fatal: true
       callbacks_enabled: profile_tasks
-      stdout_callback: yaml
+      callback_result_format: yaml
     privilege_escalation:
       become: true
       become_user: root

--- a/molecule/federation-2nd/molecule.yml
+++ b/molecule/federation-2nd/molecule.yml
@@ -52,7 +52,7 @@ provisioner:
       retry_files_enabled: false
       any_errors_fatal: true
       callbacks_enabled: profile_tasks
-      stdout_callback: yaml
+      callback_result_format: yaml
     privilege_escalation:
       become: true
       become_user: root

--- a/molecule/prometheus-ha/molecule.yml
+++ b/molecule/prometheus-ha/molecule.yml
@@ -53,7 +53,7 @@ provisioner:
       retry_files_enabled: false
       any_errors_fatal: true
       callbacks_enabled: profile_tasks
-      stdout_callback: yaml
+      callback_result_format: yaml
     privilege_escalation:
       become: true
       become_user: root

--- a/molecule/ssl-ha/molecule.yml
+++ b/molecule/ssl-ha/molecule.yml
@@ -56,7 +56,7 @@ provisioner:
       retry_files_enabled: false
       any_errors_fatal: true
       callbacks_enabled: profile_tasks
-      stdout_callback: yaml
+      callback_result_format: yaml
     privilege_escalation:
       become: true
       become_user: root

--- a/roles/ceph/frontend/tasks/main.yml
+++ b/roles/ceph/frontend/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - when: ceph.uuid is falsy
-  delegate_to: "{{ groups[node_group | d('node')][0] }}"
+  delegate_to: "{{ groups.get(node_group | d('node'), [omit])[0] }}"
   block:
     - name: Slurp UUID
       ansible.builtin.slurp:
@@ -17,5 +17,5 @@
           uuid: >-
             {{ (_slurp[0].content | b64decode) if _slurp is truthy else None }}
         _slurp: >-
-          {{ play_hosts | map('extract', hostvars, ['slurp']) | selectattr('failed', 'false') | list }}
+          {{ ansible_play_batch | map('extract', hostvars, ['slurp']) | selectattr('failed', 'false') | list }}
       run_once: true

--- a/roles/ceph/node/tasks/main.yml
+++ b/roles/ceph/node/tasks/main.yml
@@ -24,7 +24,7 @@
     group: oneadmin
     mode: u=rwx,go=rx
 
-- delegate_to: "{{ groups[mon_group_name | d('mons')][0] }}"
+- delegate_to: "{{ groups.get(mon_group_name | d('mons'), [omit])[0] }}"
   run_once: true
   block:
     - name: Ensure pool exists
@@ -108,7 +108,7 @@
             {{ new_uuid }}
       run_once: true
 
-- delegate_to: "{{ groups[mon_group_name | d('mons')][0] }}"
+- delegate_to: "{{ groups.get(mon_group_name | d('mons'), [omit])[0] }}"
   run_once: true
   block:
     - name: Get keyring

--- a/roles/datastore/generic/tasks/common.yml
+++ b/roles/datastore/generic/tasks/common.yml
@@ -46,6 +46,7 @@
     # NOTE: It doesn't really make sense to symlink /var/lib/one/datastores/,
     #       so we use that as a skip condition.
     - _mount_path != '/var/lib/one/datastores'
+    - ds_dict[item].id is defined
   vars:
     # This isn't strictly a "mountpoint" (that's completely irrelevant).
     _mount_path: >-

--- a/roles/datastore/simple/tasks/frontend.yml
+++ b/roles/datastore/simple/tasks/frontend.yml
@@ -23,7 +23,7 @@
   loop: >-
     {{ range(ds_items.image | map(attribute=0)
                             | select
-                            | count) }}
+                            | count) | list }}
   vars:
     _mount_path: >-
       {{ ds_items.image[item].0.path | normpath }}
@@ -40,7 +40,7 @@
   loop: >-
     {{ range(ds_items.file | map(attribute=0)
                            | select
-                           | count) }}
+                           | count) | list }}
   vars:
     _mount_path: >-
       {{ ds_items.file[item].0.path | normpath }}

--- a/roles/datastore/simple/tasks/node.yml
+++ b/roles/datastore/simple/tasks/node.yml
@@ -25,7 +25,7 @@
       loop: >-
         {{ range(ds_items.image | map(attribute=0)
                                 | select
-                                | count) }}
+                                | count) | list }}
       vars:
         _mount_path: >-
           {{ ds_items.image[item].0.path | normpath }}
@@ -42,7 +42,7 @@
   loop: >-
     {{ range(ds_items.system | map(attribute=0)
                              | select
-                             | count) }}
+                             | count) | list }}
   vars:
     _mount_path: >-
       {{ ds_items.system[item].0.path | normpath }}

--- a/roles/helper/keys/tasks/main.yml
+++ b/roles/helper/keys/tasks/main.yml
@@ -46,4 +46,4 @@
           ansible.posix.authorized_key:
             user: "{{ slurp.results[item].item }}"
             key: "{{ slurp.results[item].content | b64decode | trim }}"
-          loop: "{{ range(slurp.results | count) }}"
+          loop: "{{ range(slurp.results | count) | list }}"

--- a/roles/opennebula/leader/tasks/main.yml
+++ b/roles/opennebula/leader/tasks/main.yml
@@ -40,7 +40,7 @@
           vars:
             _leader: "{{ hostvars[item].leader }}"
             _federation: "{{ hostvars[item].federation }}"
-          loop: "{{ play_hosts }}"
+          loop: "{{ ansible_play_batch }}"
 
         - name: Get Zone
           ansible.builtin.shell:

--- a/roles/opennebula/server/tasks/config.yml
+++ b/roles/opennebula/server/tasks/config.yml
@@ -107,7 +107,9 @@
       notify:
         - Restart OpenNebula
 
-- when: sched_drs is mapping
+- when:
+    - sched_drs is defined
+    - sched_drs is mapping
   block:
     - name: Check if drs configuration exists
       ansible.builtin.stat:
@@ -126,55 +128,57 @@
           - when: "{{ sched_drs.DEFAULT_SCHED.SOLVER is defined }}"
             put:
               path: [DEFAULT_SCHED, SOLVER]
-              value: "{{ sched_drs.DEFAULT_SCHED.SOLVER | d(omit) }}"
+              value: "{{ sched_drs.DEFAULT_SCHED.SOLVER | d() }}"
 
           - when: "{{ sched_drs.DEFAULT_SCHED.SOLVER_PATH is defined }}"
             put:
               path: [DEFAULT_SCHED, SOLVER_PATH]
-              value: "{{ sched_drs.DEFAULT_SCHED.SOLVER_PATH | d(omit) }}"
+              value: "{{ sched_drs.DEFAULT_SCHED.SOLVER_PATH | d() }}"
 
           - when: "{{ sched_drs.PLACE.POLICY is defined }}"
             put:
               path: [PLACE, POLICY]
-              value: "{{ sched_drs.PLACE.POLICY | d(omit) }}"
+              value: "{{ sched_drs.PLACE.POLICY | d() }}"
 
           - when: "{{ sched_drs.PLACE.WEIGHTS is defined }}"
             put:
               path: [PLACE, WEIGHTS]
-              value: "{{ sched_drs.PLACE.WEIGHTS | d(omit) }}"
+              value: "{{ sched_drs.PLACE.WEIGHTS | d() }}"
 
           - when: "{{ sched_drs.OPTIMIZE.POLICY is defined }}"
             put:
               path: [OPTIMIZE, POLICY]
-              value: "{{ sched_drs.OPTIMIZE.POLICY | d(omit) }}"
+              value: "{{ sched_drs.OPTIMIZE.POLICY | d() }}"
 
           - when: "{{ sched_drs.OPTIMIZE.MIGRATION_THRESHOLD is defined }}"
             put:
               path: [OPTIMIZE, MIGRATION_THRESHOLD]
-              value: "{{ sched_drs.OPTIMIZE.MIGRATION_THRESHOLD | d(omit) }}"
+              value: "{{ sched_drs.OPTIMIZE.MIGRATION_THRESHOLD | d() }}"
 
           - when: "{{ sched_drs.OPTIMIZE.WEIGHTS is defined }}"
             put:
               path: [OPTIMIZE, WEIGHTS]
-              value: "{{ sched_drs.OPTIMIZE.WEIGHTS | d(omit) }}"
+              value: "{{ sched_drs.OPTIMIZE.WEIGHTS | d() }}"
 
           - when: "{{ sched_drs.PREDICTIVE is defined }}"
             put:
               path: [PREDICTIVE]
-              value: "{{ sched_drs.PREDICTIVE | d(omit) }}"
+              value: "{{ sched_drs.PREDICTIVE | d() }}"
 
           - when: "{{ sched_drs.MEMORY_SYSTEM_DS_SCALE is defined }}"
             put:
               path: [MEMORY_SYSTEM_DS_SCALE]
-              value: "{{ sched_drs.MEMORY_SYSTEM_DS_SCALE | d(omit) }}"
+              value: "{{ sched_drs.MEMORY_SYSTEM_DS_SCALE | d() }}"
 
           - when: "{{ sched_drs.DIFFERENT_VNETS is defined }}"
             put:
               path: [DIFFERENT_VNETS]
-              value: "{{ sched_drs.DIFFERENT_VNETS | d(omit) }}"
+              value: "{{ sched_drs.DIFFERENT_VNETS | d() }}"
       when: stat_drs_conf.stat.exists is true
 
-- when: sched_rank is mapping
+- when:
+    - sched_rank is defined
+    - sched_rank is mapping
   block:
     - name: Check if rank configuration exists
       ansible.builtin.stat:
@@ -193,55 +197,55 @@
           - when: "{{ sched_rank.MEMORY_SYSTEM_DS_SCALE is defined }}"
             put:
               path: [MEMORY_SYSTEM_DS_SCALE]
-              value: '{{ sched_rank.MAX_HOST | d(omit) }}'
+              value: '{{ sched_rank.MAX_HOST | d() }}'
 
           - when: "{{ sched_rank.MAX_HOST is defined }}"
             put:
               path: [MAX_HOST]
-              value: '{{ sched_rank.MAX_HOST | d(omit) }}'
+              value: '{{ sched_rank.MAX_HOST | d() }}'
 
           - when: "{{ sched_rank.DIFFERENT_VNETS is defined }}"
             put:
               path: [DIFFERENT_VNETS]
-              value: '{{ "YES" if (sched_rank.DIFFERENT_VNETS | d(omit) | bool) else "NO" }}'
+              value: '{{ "YES" if (sched_rank.DIFFERENT_VNETS | d(true) | bool) else "NO" }}'
 
           - when: "{{ sched_rank.DEFAULT_SCHED.POLICY is defined }}"
             put:
               path: [DEFAULT_SCHED, POLICY]
-              value: '{{ sched_rank.DEFAULT_SCHED.POLICY | d(omit) }}'
+              value: '{{ sched_rank.DEFAULT_SCHED.POLICY | d() }}'
 
           - when: "{{ sched_rank.DEFAULT_SCHED.RANK is defined }}"
             put:
               path: [DEFAULT_SCHED, RANK]
-              value: '"{{ sched_rank.DEFAULT_SCHED.RANK | d(omit) }}"'
+              value: '"{{ sched_rank.DEFAULT_SCHED.RANK | d() }}"'
 
           - when: "{{ sched_rank.DEFAULT_DS_SCHED.POLICY is defined }}"
             put:
               path: [DEFAULT_DS_SCHED, POLICY]
-              value: '{{ sched_rank.DEFAULT_DS_SCHED.POLICY | d(omit) }}'
+              value: '{{ sched_rank.DEFAULT_DS_SCHED.POLICY | d() }}'
 
           - when: "{{ sched_rank.DEFAULT_DS_SCHED.RANK is defined }}"
             put:
               path: [DEFAULT_DS_SCHED, RANK]
-              value: '"{{ sched_rank.DEFAULT_DS_SCHED.RANK | d(omit) }}"'
+              value: '"{{ sched_rank.DEFAULT_DS_SCHED.RANK | d() }}"'
 
           - when: "{{ sched_rank.DEFAULT_NIC_SCHED.POLICY is defined }}"
             put:
               path: [DEFAULT_NIC_SCHED, POLICY]
-              value: '{{ sched_rank.DEFAULT_NIC_SCHED.POLICY | d(omit) }}'
+              value: '{{ sched_rank.DEFAULT_NIC_SCHED.POLICY | d() }}'
 
           - when: "{{ sched_rank.DEFAULT_NIC_SCHED.RANK is defined }}"
             put:
               path: [DEFAULT_NIC_SCHED, RANK]
-              value: '"{{ sched_rank.DEFAULT_NIC_SCHED.RANK | d(omit) }}"'
+              value: '"{{ sched_rank.DEFAULT_NIC_SCHED.RANK | d() }}"'
 
           - when: "{{ sched_rank.LOG.SYSTEM is defined }}"
             put:
               path: [LOG, SYSTEM]
-              value: '"{{ sched_rank.LOG.SYSTEM | d(omit) }}"'
+              value: '"{{ sched_rank.LOG.SYSTEM | d() }}"'
 
           - when: "{{ sched_rank.LOG.DEBUG_LEVEL is defined }}"
             put:
               path: [LOG, DEBUG_LEVEL]
-              value: '{{ sched_rank.LOG.DEBUG_LEVEL | d(omit) }}'
+              value: '{{ sched_rank.LOG.DEBUG_LEVEL | d() }}'
       when: stat_rank_conf.stat.exists is true

--- a/roles/precheck/tasks/site.yml
+++ b/roles/precheck/tasks/site.yml
@@ -136,7 +136,7 @@
 
 - name: Check if distro family is supported
   ansible.builtin.assert:
-    that: ansible_os_family in {{ _supported }}
+    that: ansible_os_family in _supported
   vars:
     _supported:
       - Debian
@@ -144,7 +144,7 @@
 
 - name: Check if distro is supported
   ansible.builtin.assert:
-    that: ansible_distribution in {{ _supported }}
+    that: ansible_distribution in _supported
   vars:
     _supported:
       - AlmaLinux
@@ -156,8 +156,8 @@
   ansible.builtin.assert:
     that: (node_hv is undefined)
           or
-          (node_hv | lower in {{ _supported }})
-    msg: Please use one of the supported hypervisors {{ _supported }}.
+          (node_hv | lower in _supported)
+    msg: Please use one of the supported hypervisors _supported.
   vars:
     _supported:
       - kvm
@@ -187,7 +187,7 @@
   ansible.builtin.assert:
     that: "{{ 0 == (_loop[item].query | flatten | count) }}"
     msg: "{{ _loop[item].msg }}: {{ _loop[item].query | to_json }}"
-  loop: "{{ range(_loop | count) }}"
+  loop: "{{ range(_loop | count) | list }}"
   vars:
     _required: [":service_port", ":remote_addr", ":remote_port"]
     _optional: [":networks"]

--- a/roles/repository/tasks/ceph.yml
+++ b/roles/repository/tasks/ceph.yml
@@ -20,7 +20,7 @@
         #       That way we make sure:
         #       - the key is downloaded only once and only when necessary
         #       - keys are identical everywhere
-        - when: repo_constraints.ceph.hosts | select('in', play_hosts)
+        - when: repo_constraints.ceph.hosts | select('in', ansible_play_batch)
                                             | map('extract', hostvars, ['stat', 'stat', 'exists']) is not all
           block:
             - name: Download Ceph GPG key (once)

--- a/roles/repository/tasks/frr.yml
+++ b/roles/repository/tasks/frr.yml
@@ -20,7 +20,7 @@
         #       That way we make sure:
         #       - the key is downloaded only once and only when necessary
         #       - keys are identical everywhere
-        - when: repo_constraints.frr.hosts | select('in', play_hosts)
+        - when: repo_constraints.frr.hosts | select('in', ansible_play_batch)
                                            | map('extract', hostvars, ['stat', 'stat', 'exists']) is not all
           block:
             - name: Download Free Range Routing GPG key (once)

--- a/roles/repository/tasks/grafana.yml
+++ b/roles/repository/tasks/grafana.yml
@@ -20,7 +20,7 @@
         #       That way we make sure:
         #       - the key is downloaded only once and only when necessary
         #       - keys are identical everywhere
-        - when: repo_constraints.grafana.hosts | select('in', play_hosts)
+        - when: repo_constraints.grafana.hosts | select('in', ansible_play_batch)
                                                | map('extract', hostvars, ['stat', 'stat', 'exists']) is not all
           block:
             - name: Download Grafana GPG key (once)

--- a/roles/repository/tasks/opennebula.yml
+++ b/roles/repository/tasks/opennebula.yml
@@ -51,7 +51,7 @@
         #       That way we make sure:
         #       - the key is downloaded only once and only when necessary
         #       - keys are identical everywhere
-        - when: repo_constraints.opennebula.hosts | select('in', play_hosts)
+        - when: repo_constraints.opennebula.hosts | select('in', ansible_play_batch)
                                                   | map('extract', hostvars, ['stat', 'stat', 'exists']) is not all
           block:
             - name: Download OpenNebula GPG key (once)


### PR DESCRIPTION
- Always define galaxy collections path (fix)
- Always convert range results to lists (fix)
- Remove template delimiters from asserts (fix)
- Check if sched_drs and sched_rank are defined (fix)
- Check if ds_dict[item].id is defined (fix)
- Ensure delegate_to expressions are never undefined (fix)
- Use callback_result_format instead of stdout_callback (deprecation)
- Use ansible_play_batch instead of play_hosts (deprecation)
- Do not use d(omit) idiom (deprecation)
- Keep compatibility with ansible-core<2.16 and ansible-core<2.17