### PR TITLE
F #-: Ignore warning from untrusted repos

### DIFF
--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -28,3 +28,4 @@
       {{ repos_enabled | map('regex_replace', '^(.*)$', '\g<1>_repo')
                        | map('extract', hostvars[inventory_hostname], ['changed'])
                        | map('default', false) }}
+  ignore_errors: true # warning ignore-errors


### PR DESCRIPTION
When using an OpenNebula repository as a source that is not part of an official release, on Debian-based systems the Ansible ansible.builtin.package module relies on apt. In this case, apt may emit warnings (for example, related to GPG signatures), which Ansible treats as errors even when `opennebula_repo_force_trusted = yes`, causing the playbook execution to fail.
