### PR TITLE
F #-: Install EPEL package in RHEL

### DIFF
--- a/roles/repository/defaults/main.yml
+++ b/roles/repository/defaults/main.yml
@@ -145,16 +145,28 @@ opennebula_repo_url_defaults:
 
 opennebula_repo_pre_enable_defaults:
   AlmaLinux:
-    config_manager:
-      '8': [epel, powertools, ha]
-      '9': [epel, crb, highavailability]
     subscription_manager:
       '8': []
       '9': []
-  RedHat:
+      '10': []
+    extra_rpms:
+      '8': []
+      '9': []
+      '10': []
     config_manager:
-      '8': [epel]
-      '9': [epel]
+      '8': [epel, powertools, ha]
+      '9': [epel, crb, highavailability]
+      '10': [epel, crb, highavailability]
+  RedHat:
     subscription_manager:
       '8': [codeready-builder-for-rhel-8-x86_64-rpms, rhel-8-for-x86_64-highavailability-rpms]
       '9': [codeready-builder-for-rhel-9-x86_64-rpms, rhel-9-for-x86_64-highavailability-rpms]
+      '10': [codeready-builder-for-rhel-10-x86_64-rpms, rhel-10-for-x86_64-highavailability-rpms]
+    extra_rpms:
+      '8': ["https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"]
+      '9': ["https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"]
+      '10': ["https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm"]
+    config_manager:
+      '8': [epel]
+      '9': [epel]
+      '10': [epel]

--- a/roles/repository/tasks/opennebula.yml
+++ b/roles/repository/tasks/opennebula.yml
@@ -6,38 +6,35 @@
         opennebula_repo_pre_enable: >-
           {{ opennebula_repo_pre_enable_defaults | combine(opennebula_repo_pre_enable | d({}), recursive=true) }}
 
-    - name: Install EPEL release package (if needed)
-      ansible.builtin.dnf:
-        name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
-        state: present
-      when: ansible_distribution == 'RedHat' and "'epel' in _config_manager"
-      vars:
-        _config_manager: >-
-          {{ opennebula_repo_pre_enable[ansible_distribution].config_manager[ansible_distribution_major_version]
-             | d([])
-             | map('replace', "'", '') }}
-
     - name: Enable required DNF extra repos
       ansible.builtin.shell:
         cmd: |
           set -o errexit
 
-          {% if _config_manager | count > 0 %}
-          dnf config-manager -y --enable {{ _config_manager | map('regex_replace', '^(.*)$', "'\g<1>'") | join(' ') }}
-          {% endif %}
-
           {% if _subscription_manager | count > 0 %}
           subscription-manager repos {{ _subscription_manager | map('regex_replace', '^(.*)$', "--enable '\g<1>'") | join(' ') }}
+          {% endif %}
+
+          {% if _extra_rpms | count > 0 %}
+          dnf install -y {{ _extra_rpms | map('regex_replace', '^(.*)$', "'\g<1>'") | join(' ') }}
+          {% endif %}
+
+          {% if _config_manager | count > 0 %}
+          dnf config-manager -y --enable {{ _config_manager | map('regex_replace', '^(.*)$', "'\g<1>'") | join(' ') }}
           {% endif %}
         executable: /bin/bash
       changed_when: false
       vars:
-        _config_manager: >-
-          {{ opennebula_repo_pre_enable[ansible_distribution].config_manager[ansible_distribution_major_version]
-             | d([])
-             | map('replace', "'", '') }}
         _subscription_manager: >-
           {{ opennebula_repo_pre_enable[ansible_distribution].subscription_manager[ansible_distribution_major_version]
+             | d([])
+             | map('replace', "'", '') }}
+        _extra_rpms: >-
+          {{ opennebula_repo_pre_enable[ansible_distribution].extra_rpms[ansible_distribution_major_version]
+             | d([])
+             | map('replace', "'", '') }}
+        _config_manager: >-
+          {{ opennebula_repo_pre_enable[ansible_distribution].config_manager[ansible_distribution_major_version]
              | d([])
              | map('replace', "'", '') }}
 


### PR DESCRIPTION
If we want to enable the EPEL repository we need to install the package first (doesn't come installed by default)