### PR TITLE
Add POC Cognit inventory and playbook for LOCAL frontend package installation

### DIFF
--- a/poc/cognit/README.md
+++ b/poc/cognit/README.md
@@ -1,0 +1,30 @@
+# POC Cognit
+
+This Ansible playbook lets you test Cognit packages locally: it adds the project apt repo and installs the package on a frontend VM.
+
+You need a VM already running locally (e.g. on your OpenNebula) that can reach the apt repo at http://5.2.88.196/repo/ and has root SSH. Tested with Ubuntu 24.04, 4 GB RAM, 2 vCPUs, 20 GB disk.
+
+**Check before running the playbook**
+
+1. VM can reach the repo (from laptop, as oneadmin):
+   ```bash
+   onevm ssh <VM_ID> --cmd "ping -c2 5.2.88.196"
+   onevm ssh <VM_ID> --cmd "curl -sI http://5.2.88.196/repo/"
+   ```
+   Ping uses the host; curl uses the URL. If ping fails, run on the OpenNebula host: `sudo ./poc/cognit/scripts/enable-vm-repo-access.sh`
+
+2. Inventory: in `poc/cognit/inventory.yml` set `ansible_host` under `frontend.hosts.f1` to your VM IP.
+
+**Run the playbook** (from one-deploy repo root):
+
+```bash
+pyenv shell ansible-6.0.0
+ansible-playbook -i poc/cognit/inventory.yml poc/cognit/playbook.yml
+```
+
+**Check it worked**
+
+- Repo: `onevm ssh <VM_ID> --cmd "cat /etc/apt/sources.list.d/cognit.list"`
+- Package: `onevm ssh <VM_ID> --cmd "dpkg -l opennebula-cognit-frontend"`
+
+Different package from same repo: `ansible-playbook -i poc/cognit/inventory.yml poc/cognit/playbook.yml -e cognit_package=your-package`

--- a/poc/cognit/inventory.yml
+++ b/poc/cognit/inventory.yml
@@ -1,0 +1,32 @@
+---
+# POC Cognit – frontend-only inventory for one-deploy + cognit package.
+# Replace ansible_host with your Ubuntu 24 frontend VM IP.
+
+all:
+  vars:
+    ansible_user: root
+    one_version: "6.8"
+    one_pass: opennebulapass
+    db_backend: SQLite
+    ds:
+      mode: ssh
+    vn:
+      admin_net:
+        managed: true
+        template:
+          VN_MAD: bridge
+          PHYDEV: eth0
+          BRIDGE: br0
+          AR:
+            TYPE: IP4
+            IP: 172.20.0.100
+            SIZE: 48
+          NETWORK_ADDRESS: 172.20.0.0
+          NETWORK_MASK: 255.255.255.0
+          GATEWAY: 172.20.0.1
+          DNS: 1.1.1.1
+
+frontend:
+  hosts:
+    f1:
+      ansible_host: 172.20.0.4  # set to your Ubuntu 24 VM IP

--- a/poc/cognit/playbook.yml
+++ b/poc/cognit/playbook.yml
@@ -1,0 +1,30 @@
+---
+# POC Cognit – add project apt repo and install package on frontend.
+# Run after one-deploy has installed the OpenNebula frontend.
+# Usage: ansible-playbook -i poc/cognit/inventory.yml poc/cognit/playbook.yml
+
+- name: Install POC Cognit package on frontend
+  hosts: frontend
+  gather_facts: true
+  vars:
+    cognit_repo_url: "http://5.2.88.196/repo/"
+    cognit_repo_component: "poc-cognit"
+    cognit_package: "opennebula-cognit-frontend"
+  tasks:
+    - name: Add POC Cognit apt repository
+      ansible.builtin.copy:
+        dest: /etc/apt/sources.list.d/cognit.list
+        content: "deb [trusted=yes] {{ cognit_repo_url }} {{ ansible_distribution_release }} {{ cognit_repo_component }}\n"
+        mode: "0644"
+      when: ansible_os_family == "Debian"
+
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+      when: ansible_os_family == "Debian"
+
+    - name: Install POC Cognit frontend package
+      ansible.builtin.apt:
+        name: "{{ cognit_package }}"
+        state: present
+      when: ansible_os_family == "Debian"


### PR DESCRIPTION
- Created `inventory.yml` for defining Ansible inventory and variables.
- Added `playbook.yml` to install the POC Cognit package on a frontend VM.
- Updated `README.md` with usage instructions and prerequisites for running the playbook.