### PR TITLE
F OpenNebula/engineering#751: Use drop-ins to configure oneprometheus systemd units

### DIFF
--- a/roles/prometheus/common/defaults/main.yml
+++ b/roles/prometheus/common/defaults/main.yml
@@ -1,2 +1,52 @@
 ---
 node_hypervisor: kvm # currently "kvm" only
+
+oneprometheus_limits_defaults:
+  grafana-server.service:
+    CPUQuota: 100%
+    CPUWeight: 100
+    MemoryHigh: 1024M
+    MemoryMax: 2048M
+    IOWeight: null
+    IOReadBandwidthMax: null
+    IOWriteBandwidthMax: null
+  opennebula-alertmanager.service:
+    CPUQuota: 25%
+    CPUWeight: 150
+    MemoryHigh: 128M
+    MemoryMax: 256M
+    IOWeight: null
+    IOReadBandwidthMax: null
+    IOWriteBandwidthMax: null
+  opennebula-exporter.service:
+    CPUQuota: 25%
+    CPUWeight: 25
+    MemoryHigh: 128M
+    MemoryMax: 256M
+    IOWeight: null
+    IOReadBandwidthMax: null
+    IOWriteBandwidthMax: null
+  opennebula-libvirt-exporter.service:
+    CPUQuota: 25%
+    CPUWeight: 25
+    MemoryHigh: 128M
+    MemoryMax: 256M
+    IOWeight: null
+    IOReadBandwidthMax: null
+    IOWriteBandwidthMax: null
+  opennebula-node-exporter.service:
+    CPUQuota: 25%
+    CPUWeight: 25
+    MemoryHigh: 64M
+    MemoryMax: 128M
+    IOWeight: null
+    IOReadBandwidthMax: null
+    IOWriteBandwidthMax: null
+  opennebula-prometheus.service:
+    CPUQuota: 100%
+    CPUWeight: 100
+    MemoryHigh: 1024M
+    MemoryMax: 2048M
+    IOWeight: 200
+    IOReadBandwidthMax: /var/lib/prometheus 50M
+    IOWriteBandwidthMax: /var/lib/prometheus 25M

--- a/roles/prometheus/common/tasks/main.yml
+++ b/roles/prometheus/common/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Compute facts (Prometheus)
+  ansible.builtin.set_fact:
+    oneprometheus_limits: >-
+      {{ oneprometheus_limits_defaults | combine(oneprometheus_limits | d({}), recursive=true) }}

--- a/roles/prometheus/common/templates/grafana-server.service.jinja
+++ b/roles/prometheus/common/templates/grafana-server.service.jinja
@@ -1,0 +1,31 @@
+# managed by one-deploy
+[Service]
+{# --- #}
+{% if oneprometheus_limits['grafana-server.service'].CPUQuota is not none %}
+CPUQuota={{ oneprometheus_limits['grafana-server.service'].CPUQuota }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['grafana-server.service'].CPUWeight is not none %}
+CPUWeight={{ oneprometheus_limits['grafana-server.service'].CPUWeight }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['grafana-server.service'].MemoryHigh is not none %}
+MemoryHigh={{ oneprometheus_limits['grafana-server.service'].MemoryHigh }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['grafana-server.service'].MemoryMax is not none %}
+MemoryMax={{ oneprometheus_limits['grafana-server.service'].MemoryMax }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['grafana-server.service'].IOWeight is not none %}
+IOWeight={{ oneprometheus_limits['grafana-server.service'].IOWeight }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['grafana-server.service'].IOReadBandwidthMax is not none %}
+IOReadBandwidthMax={{ oneprometheus_limits['grafana-server.service'].IOReadBandwidthMax }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['grafana-server.service'].IOWriteBandwidthMax is not none %}
+IOWriteBandwidthMax={{ oneprometheus_limits['grafana-server.service'].IOWriteBandwidthMax }}
+{% endif %}
+{# --- #}

--- a/roles/prometheus/common/templates/opennebula-alertmanager.service.jinja
+++ b/roles/prometheus/common/templates/opennebula-alertmanager.service.jinja
@@ -1,0 +1,39 @@
+# managed by one-deploy
+[Service]
+{% if _peers | length > 0 %}
+# NOTE: Providing cluster peers from the command line seems to be
+#       the only supported way to configure HA Alertmanager.
+ExecStart=
+ExecStart=/usr/bin/alertmanager \
+          --config.file=/etc/one/alertmanager/alertmanager.yml \
+          --storage.path=/var/lib/alertmanager/data/ {{ _peers }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-alertmanager.service'].CPUQuota is not none %}
+CPUQuota={{ oneprometheus_limits['opennebula-alertmanager.service'].CPUQuota }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-alertmanager.service'].CPUWeight is not none %}
+CPUWeight={{ oneprometheus_limits['opennebula-alertmanager.service'].CPUWeight }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-alertmanager.service'].MemoryHigh is not none %}
+MemoryHigh={{ oneprometheus_limits['opennebula-alertmanager.service'].MemoryHigh }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-alertmanager.service'].MemoryMax is not none %}
+MemoryMax={{ oneprometheus_limits['opennebula-alertmanager.service'].MemoryMax }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-alertmanager.service'].IOWeight is not none %}
+IOWeight={{ oneprometheus_limits['opennebula-alertmanager.service'].IOWeight }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-alertmanager.service'].IOReadBandwidthMax is not none %}
+IOReadBandwidthMax={{ oneprometheus_limits['opennebula-alertmanager.service'].IOReadBandwidthMax }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-alertmanager.service'].IOWriteBandwidthMax is not none %}
+IOWriteBandwidthMax={{ oneprometheus_limits['opennebula-alertmanager.service'].IOWriteBandwidthMax }}
+{% endif %}
+{# --- #}

--- a/roles/prometheus/common/templates/opennebula-exporter.service.jinja
+++ b/roles/prometheus/common/templates/opennebula-exporter.service.jinja
@@ -1,0 +1,31 @@
+# managed by one-deploy
+[Service]
+{# --- #}
+{% if oneprometheus_limits['opennebula-exporter.service'].CPUQuota is not none %}
+CPUQuota={{ oneprometheus_limits['opennebula-exporter.service'].CPUQuota }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-exporter.service'].CPUWeight is not none %}
+CPUWeight={{ oneprometheus_limits['opennebula-exporter.service'].CPUWeight }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-exporter.service'].MemoryHigh is not none %}
+MemoryHigh={{ oneprometheus_limits['opennebula-exporter.service'].MemoryHigh }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-exporter.service'].MemoryMax is not none %}
+MemoryMax={{ oneprometheus_limits['opennebula-exporter.service'].MemoryMax }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-exporter.service'].IOWeight is not none %}
+IOWeight={{ oneprometheus_limits['opennebula-exporter.service'].IOWeight }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-exporter.service'].IOReadBandwidthMax is not none %}
+IOReadBandwidthMax={{ oneprometheus_limits['opennebula-exporter.service'].IOReadBandwidthMax }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-exporter.service'].IOWriteBandwidthMax is not none %}
+IOWriteBandwidthMax={{ oneprometheus_limits['opennebula-exporter.service'].IOWriteBandwidthMax }}
+{% endif %}
+{# --- #}

--- a/roles/prometheus/common/templates/opennebula-libvirt-exporter.service.jinja
+++ b/roles/prometheus/common/templates/opennebula-libvirt-exporter.service.jinja
@@ -1,0 +1,31 @@
+# managed by one-deploy
+[Service]
+{# --- #}
+{% if oneprometheus_limits['opennebula-libvirt-exporter.service'].CPUQuota is not none %}
+CPUQuota={{ oneprometheus_limits['opennebula-libvirt-exporter.service'].CPUQuota }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-libvirt-exporter.service'].CPUWeight is not none %}
+CPUWeight={{ oneprometheus_limits['opennebula-libvirt-exporter.service'].CPUWeight }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-libvirt-exporter.service'].MemoryHigh is not none %}
+MemoryHigh={{ oneprometheus_limits['opennebula-libvirt-exporter.service'].MemoryHigh }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-libvirt-exporter.service'].MemoryMax is not none %}
+MemoryMax={{ oneprometheus_limits['opennebula-libvirt-exporter.service'].MemoryMax }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-libvirt-exporter.service'].IOWeight is not none %}
+IOWeight={{ oneprometheus_limits['opennebula-libvirt-exporter.service'].IOWeight }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-libvirt-exporter.service'].IOReadBandwidthMax is not none %}
+IOReadBandwidthMax={{ oneprometheus_limits['opennebula-libvirt-exporter.service'].IOReadBandwidthMax }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-libvirt-exporter.service'].IOWriteBandwidthMax is not none %}
+IOWriteBandwidthMax={{ oneprometheus_limits['opennebula-libvirt-exporter.service'].IOWriteBandwidthMax }}
+{% endif %}
+{# --- #}

--- a/roles/prometheus/common/templates/opennebula-node-exporter.service.jinja
+++ b/roles/prometheus/common/templates/opennebula-node-exporter.service.jinja
@@ -1,0 +1,31 @@
+# managed by one-deploy
+[Service]
+{# --- #}
+{% if oneprometheus_limits['opennebula-node-exporter.service'].CPUQuota is not none %}
+CPUQuota={{ oneprometheus_limits['opennebula-node-exporter.service'].CPUQuota }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-node-exporter.service'].CPUWeight is not none %}
+CPUWeight={{ oneprometheus_limits['opennebula-node-exporter.service'].CPUWeight }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-node-exporter.service'].MemoryHigh is not none %}
+MemoryHigh={{ oneprometheus_limits['opennebula-node-exporter.service'].MemoryHigh }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-node-exporter.service'].MemoryMax is not none %}
+MemoryMax={{ oneprometheus_limits['opennebula-node-exporter.service'].MemoryMax }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-node-exporter.service'].IOWeight is not none %}
+IOWeight={{ oneprometheus_limits['opennebula-node-exporter.service'].IOWeight }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-node-exporter.service'].IOReadBandwidthMax is not none %}
+IOReadBandwidthMax={{ oneprometheus_limits['opennebula-node-exporter.service'].IOReadBandwidthMax }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-node-exporter.service'].IOWriteBandwidthMax is not none %}
+IOWriteBandwidthMax={{ oneprometheus_limits['opennebula-node-exporter.service'].IOWriteBandwidthMax }}
+{% endif %}
+{# --- #}

--- a/roles/prometheus/common/templates/opennebula-prometheus.service.jinja
+++ b/roles/prometheus/common/templates/opennebula-prometheus.service.jinja
@@ -1,0 +1,31 @@
+# managed by one-deploy
+[Service]
+{# --- #}
+{% if oneprometheus_limits['opennebula-prometheus.service'].CPUQuota is not none %}
+CPUQuota={{ oneprometheus_limits['opennebula-prometheus.service'].CPUQuota }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-prometheus.service'].CPUWeight is not none %}
+CPUWeight={{ oneprometheus_limits['opennebula-prometheus.service'].CPUWeight }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-prometheus.service'].MemoryHigh is not none %}
+MemoryHigh={{ oneprometheus_limits['opennebula-prometheus.service'].MemoryHigh }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-prometheus.service'].MemoryMax is not none %}
+MemoryMax={{ oneprometheus_limits['opennebula-prometheus.service'].MemoryMax }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-prometheus.service'].IOWeight is not none %}
+IOWeight={{ oneprometheus_limits['opennebula-prometheus.service'].IOWeight }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-prometheus.service'].IOReadBandwidthMax is not none %}
+IOReadBandwidthMax={{ oneprometheus_limits['opennebula-prometheus.service'].IOReadBandwidthMax }}
+{% endif %}
+{# --- #}
+{% if oneprometheus_limits['opennebula-prometheus.service'].IOWriteBandwidthMax is not none %}
+IOWriteBandwidthMax={{ oneprometheus_limits['opennebula-prometheus.service'].IOWriteBandwidthMax }}
+{% endif %}
+{# --- #}

--- a/roles/prometheus/exporter/README.md
+++ b/roles/prometheus/exporter/README.md
@@ -11,10 +11,10 @@ N/A
 Role Variables
 --------------
 
-| Name              | Type  | Default | Example | Description                        |
-|-------------------|-------|---------|---------|------------------------------------|
-| `node_hypervisor` | `str` | `kvm`   |         | Currently only `kvm` is supported. |
-
+| Name                   | Type   | Default             | Example       | Description                               |
+|------------------------|--------|---------------------|---------------|-------------------------------------------|
+| `node_hypervisor`      | `str`  | `kvm`               |               | Currently only `kvm` is supported.        |
+| `oneprometheus_limits` | `dict` | (check common role) | (check below) | Define resource limits for systemd units. |
 
 Dependencies
 ------------
@@ -25,8 +25,21 @@ Example Playbook
 ----------------
 
     - hosts: node
+      vars:
+        oneprometheus_limits:
+          opennebula-libvirt-exporter.service:
+            CPUQuota: 25%
+            CPUWeight: 25
+            MemoryHigh: 128M
+            MemoryMax: 256M
+          opennebula-node-exporter.service:
+            CPUQuota: 25%
+            CPUWeight: 25
+            MemoryHigh: 64M
+            MemoryMax: 128M
       roles:
         - role: opennebula.deploy.helper.facts
+        - role: opennebula.deploy.repository
         - role: opennebula.deploy.prometheus.exporter
 
 License

--- a/roles/prometheus/exporter/tasks/main.yml
+++ b/roles/prometheus/exporter/tasks/main.yml
@@ -7,7 +7,7 @@
         repos_enabled: [opennebula]
       when: opennebula_repo is undefined
 
-    - name: Install Prometheus and dependencies
+    - name: Install Prometheus with dependencies
       ansible.builtin.package:
         name: "{{ _common + _specific[ansible_os_family] }}"
       vars:
@@ -22,11 +22,43 @@
       retries: 12
       delay: 5
 
-- name: Enable / Start Prometheus exporters (NOW)
-  ansible.builtin.service:
-    name: "{{ item }}"
-    enabled: true
-    state: started
-  loop:
-    - opennebula-libvirt-exporter
-    - opennebula-node-exporter
+- vars:
+    _loop:
+      - name: opennebula-libvirt-exporter.service
+        dest: /etc/systemd/system/opennebula-libvirt-exporter.service.d/override.conf
+        src: "{{ role_path }}/../common/templates/opennebula-libvirt-exporter.service.jinja"
+      - name: opennebula-node-exporter.service
+        dest: /etc/systemd/system/opennebula-node-exporter.service.d/override.conf
+        src: "{{ role_path }}/../common/templates/opennebula-node-exporter.service.jinja"
+  block:
+    - name: Override systemd units (mkdir)
+      ansible.builtin.file:
+        path: "{{ item.dest | dirname }}"
+        state: directory
+        owner: 0
+        group: 0
+        mode: u=rwx,go=rx
+      loop: "{{ _loop }}"
+
+    - name: Override systemd units
+      ansible.builtin.template:
+        dest: "{{ item.dest }}"
+        src: "{{ item.src }}"
+        owner: 0
+        group: 0
+        mode: u=rw,go=r
+      loop: "{{ _loop }}"
+      register: template_override_units
+
+    - name: Enable / Start / Restart Prometheus exporters (NOW)
+      ansible.builtin.systemd_service:
+        name: "{{ item.name }}"
+        enabled: true
+        state: >-
+          {{ 'restarted' if _changed else 'started' }}
+        daemon_reload: >-
+          {{ _changed }}
+      loop: "{{ _loop }}"
+      vars:
+        _changed: >-
+          {{ template_override_units is changed }}

--- a/roles/prometheus/grafana/README.md
+++ b/roles/prometheus/grafana/README.md
@@ -11,10 +11,11 @@ N/A
 Role Variables
 --------------
 
-| Name      | Type   | Default   | Example       | Description                                            |
-|-----------|--------|-----------|---------------|--------------------------------------------------------|
-| `one_vip` | `str`  | undefined | `10.11.12.13` | When OpenNebula is in HA mode it points to the Leader. |
-| `leader`  | `str`  | undefined | `10.11.12.13` | When OpenNebula is in HA mode it points to the Leader. |
+| Name                   | Type   | Default             | Example       | Description                                            |
+|------------------------|--------|---------------------|---------------|--------------------------------------------------------|
+| `one_vip`              | `str`  | undefined           | `10.11.12.13` | When OpenNebula is in HA mode it points to the Leader. |
+| `leader`               | `str`  | undefined           | `10.11.12.13` | When OpenNebula is in HA mode it points to the Leader. |
+| `oneprometheus_limits` | `dict` | (check common role) | (check below) | Define resource limits for systemd units.              |
 
 Dependencies
 ------------
@@ -25,8 +26,16 @@ Example Playbook
 ----------------
 
     - hosts: grafana
+      vars:
+        oneprometheus_limits:
+          grafana-server.service:
+            CPUQuota: 100%
+            CPUWeight: 100
+            MemoryHigh: 1024M
+            MemoryMax: 2048M
       roles:
         - role: opennebula.deploy.helper.facts
+        - role: opennebula.deploy.repository
         - role: opennebula.deploy.prometheus.grafana
 
 License

--- a/roles/prometheus/grafana/tasks/main.yml
+++ b/roles/prometheus/grafana/tasks/main.yml
@@ -24,40 +24,70 @@
     name: opennebula/leader
   when: leader is undefined
 
-- name: Provision Grafana datasources
+- name: Update Grafana provisioning
   ansible.builtin.copy:
-    dest: /etc/grafana/provisioning/datasources/prometheus.yml
+    dest: "{{ item.dest }}"
+    content: "{{ item.content }}"
+    owner: 0
+    group: grafana
     mode: u=rw,go=r
-    content: |
-      apiVersion: 1
-      datasources:
-      - name: prometheus
-        type: prometheus
-        access: proxy
-        url: "http://{{ one_vip | default(leader) }}:9090"
-        isDefault: true
-        editable: false
-  register: copy_datasources
-
-- name: Provision Grafana dashboards
-  ansible.builtin.copy:
-    dest: /etc/grafana/provisioning/dashboards/opennebula.yml
-    mode: u=rw,go=r
-    content: |
-      apiVersion: 1
-      providers:
-      - name: opennebula
-        type: file
-        folder: ONE
-        options: { path: /usr/share/one/grafana/dashboards/ }
-  register: copy_dashboards
-
-- name: Enable / Start / Restart Grafana service (NOW)
-  ansible.builtin.service:
-    name: grafana-server
-    enabled: true
-    state: >-
-      {{ 'restarted' if _changed else 'started' }}
+  loop: "{{ _loop }}"
   vars:
-    _changed: >-
-      {{ (copy_datasources is changed) or (copy_dashboards is changed) }}
+    _loop:
+      - dest: /etc/grafana/provisioning/datasources/prometheus.yml
+        content: |
+          apiVersion: 1
+          datasources:
+          - name: prometheus
+            type: prometheus
+            access: proxy
+            url: "http://{{ one_vip | d(leader) }}:9090"
+            isDefault: true
+            editable: false
+      - dest: /etc/grafana/provisioning/dashboards/opennebula.yml
+        content: |
+          apiVersion: 1
+          providers:
+          - name: opennebula
+            type: file
+            folder: ONE
+            options: { path: /usr/share/one/grafana/dashboards/ }
+  register: copy_grafana_provisioning
+
+- vars:
+    _loop:
+      - name: grafana-server.service
+        dest: /etc/systemd/system/grafana-server.service.d/override.conf
+        src: "{{ role_path }}/../common/templates/grafana-server.service.jinja"
+  block:
+    - name: Override systemd units (mkdir)
+      ansible.builtin.file:
+        path: "{{ item.dest | dirname }}"
+        state: directory
+        owner: 0
+        group: 0
+        mode: u=rwx,go=rx
+      loop: "{{ _loop }}"
+
+    - name: Override systemd units
+      ansible.builtin.template:
+        dest: "{{ item.dest }}"
+        src: "{{ item.src }}"
+        owner: 0
+        group: 0
+        mode: u=rw,go=r
+      loop: "{{ _loop }}"
+      register: template_override_units
+
+    - name: Enable / Start / Restart Grafana service (NOW)
+      ansible.builtin.systemd_service:
+        name: "{{ item.name }}"
+        enabled: true
+        state: >-
+          {{ 'restarted' if _changed else 'started' }}
+        daemon_reload: >-
+          {{ _changed }}
+      loop: "{{ _loop }}"
+      vars:
+        _changed: >-
+          {{ copy_grafana_provisioning is changed or template_override_units is changed }}

--- a/roles/prometheus/server/README.md
+++ b/roles/prometheus/server/README.md
@@ -11,10 +11,11 @@ N/A
 Role Variables
 --------------
 
-| Name                  | Type  | Default       | Example       | Description                                   |
-|-----------------------|-------|---------------|---------------|-----------------------------------------------|
-| `node_hypervisor`     | `str` | `kvm`         |               | Currently only `kvm` is supported.            |
-| `alertmanager_config` | `str` | (check below) |               | Configuration YAML document for Alertmanager. |
+| Name                   | Type   | Default             | Example       | Description                                   |
+|------------------------|--------|---------------------|---------------|-----------------------------------------------|
+| `node_hypervisor`      | `str`  | `kvm`               |               | Currently only `kvm` is supported.            |
+| `alertmanager_config`  | `str`  | (check below)       |               | Configuration YAML document for Alertmanager. |
+| `oneprometheus_limits` | `dict` | (check common role) | (check below) | Define resource limits for systemd units.     |
 
 Dependencies
 ------------
@@ -49,6 +50,30 @@ Example Playbook
               target_match:
                 severity: warning
               equal: [alertname, dev, instance]
+        oneprometheus_limits:
+          opennebula-alertmanager.service:
+            CPUQuota: 25%
+            CPUWeight: 150
+            MemoryHigh: 128M
+            MemoryMax: 256M
+          opennebula-exporter.service:
+            CPUQuota: 25%
+            CPUWeight: 25
+            MemoryHigh: 128M
+            MemoryMax: 256M
+          opennebula-node-exporter.service:
+            CPUQuota: 25%
+            CPUWeight: 25
+            MemoryHigh: 64M
+            MemoryMax: 128M
+          opennebula-prometheus.service:
+            CPUQuota: 100%
+            CPUWeight: 100
+            MemoryHigh: 1024M
+            MemoryMax: 2048M
+            IOWeight: 200
+            IOReadBandwidthMax: /var/lib/prometheus 50M
+            IOWriteBandwidthMax: /var/lib/prometheus 25M
       roles:
         - role: opennebula.deploy.helper.facts
         - role: opennebula.deploy.repository

--- a/roles/prometheus/server/tasks/alertmanager.yml
+++ b/roles/prometheus/server/tasks/alertmanager.yml
@@ -2,47 +2,50 @@
 - name: Configure Alertmanager
   ansible.builtin.copy:
     dest: /etc/one/alertmanager/alertmanager.yml
+    owner: 0
+    group: 0
     mode: u=rw,go=r
     content: "{{ alertmanager_config }}"
   register: copy_alertmanager_yml
 
-- when: ansible_play_hosts_all | length > 1
-  block:
-    - name: Override Alertmanager's systemd unit (mkdir)
-      ansible.builtin.file:
-        path: /etc/systemd/system/opennebula-alertmanager.service.d/
-        state: directory
-        mode: u=rwx,go=rx
-
-    - name: Override Alertmanager's systemd unit
-      ansible.builtin.copy:
+- vars:
+    _peers: >-
+      {{ ansible_play_hosts_all | reject('in', [inventory_hostname])
+                                | map('regex_replace', '^(.*)$', ' --cluster.peer=\g<1>:9094 ')
+                                | join }}
+    _loop:
+      - name: opennebula-alertmanager.service
         dest: /etc/systemd/system/opennebula-alertmanager.service.d/override.conf
-        mode: u=rw,go=r
-        content: |
-          [Service]
-          ExecStart=
-          ExecStart=/usr/bin/alertmanager \
-                    --config.file=/etc/one/alertmanager/alertmanager.yml \
-                    --storage.path=/var/lib/alertmanager/data/ {{ _peers }}
-      vars:
-        # NOTE: Providing cluster peers from the command line seems to be
-        # the only supported way to configure HA Alertmanager.
-        _peers: >-
-          {{ ansible_play_hosts_all | reject('in', [inventory_hostname])
-                                    | map('regex_replace', '^(.*)$', ' --cluster.peer=\g<1>:9094 ')
-                                    | join }}
-      register: copy_override_conf
+        src: "{{ role_path }}/../common/templates/opennebula-alertmanager.service.jinja"
+  block:
+    - name: Override systemd units (mkdir)
+      ansible.builtin.file:
+        path: "{{ item.dest | dirname }}"
+        state: directory
+        owner: 0
+        group: 0
+        mode: u=rwx,go=rx
+      loop: "{{ _loop }}"
 
-- name: Enable / Start / Restart Alertmanager service (NOW)
-  ansible.builtin.systemd:
-    name: opennebula-alertmanager
-    enabled: true
-    state: >-
-      {{ 'restarted' if _changed else 'started' }}
-    daemon_reload: >-
-      {{ _changed }}
-  vars:
-    _changed: >-
-      {{ copy_alertmanager_yml is changed
-         or
-         (copy_override_conf is defined and copy_override_conf is changed) }}
+    - name: Override systemd units
+      ansible.builtin.template:
+        dest: "{{ item.dest }}"
+        src: "{{ item.src }}"
+        owner: 0
+        group: 0
+        mode: u=rw,go=r
+      loop: "{{ _loop }}"
+      register: template_override_units
+
+    - name: Enable / Start / Restart Alertmanager service (NOW)
+      ansible.builtin.systemd_service:
+        name: "{{ item.name }}"
+        enabled: true
+        state: >-
+          {{ 'restarted' if _changed else 'started' }}
+        daemon_reload: >-
+          {{ _changed }}
+      loop: "{{ _loop }}"
+      vars:
+        _changed: >-
+          {{ copy_alertmanager_yml is changed or template_override_units is changed }}

--- a/roles/prometheus/server/tasks/main.yml
+++ b/roles/prometheus/server/tasks/main.yml
@@ -7,7 +7,7 @@
         repos_enabled: [opennebula]
       when: opennebula_repo is undefined
 
-    - name: Install Prometheus and dependencies
+    - name: Install Prometheus with dependencies
       ansible.builtin.package:
         name: "{{ _common + _specific[ansible_os_family] }}"
       vars:

--- a/roles/prometheus/server/tasks/prometheus.yml
+++ b/roles/prometheus/server/tasks/prometheus.yml
@@ -4,32 +4,60 @@
     cmd: |
       set -o errexit
       BEFORE=$(cksum /etc/one/prometheus/prometheus.yml)
-      if /usr/share/one/prometheus/patch_datasources.rb; then
-        AFTER=$(cksum /etc/one/prometheus/prometheus.yml)
-        if [[ "$AFTER" == "$BEFORE" ]]; then
-          exit 0
-        else
-          exit 78
-        fi
+      /usr/share/one/prometheus/patch_datasources.rb
+      AFTER=$(cksum /etc/one/prometheus/prometheus.yml)
+      if [[ "$AFTER" == "$BEFORE" ]]; then
+        exit 0
+      else
+        exit 78 # EREMCHG
       fi
-      exit 1
     executable: /bin/bash
-  register: shell
+  register: shell_patch_datasources
   changed_when:
-    - shell.rc == 78 # EREMCHG "Remote address changed" 8^)
+    - shell_patch_datasources.rc in [78]
   failed_when:
-    - shell.rc != 0 and shell.rc != 78
+    - shell_patch_datasources.rc not in [0, 78]
 
-- name: Enable / Start / Restart Prometheus service and exporters (NOW)
-  ansible.builtin.service:
-    name: "{{ item }}"
-    enabled: true
-    state: >-
-      {{ 'restarted' if _changed else 'started' }}
-  loop:
-    - opennebula-exporter
-    - opennebula-node-exporter
-    - opennebula-prometheus
-  vars:
-    _changed: >-
-      {{ shell is changed }}
+- vars:
+    _loop:
+      - name: opennebula-exporter.service
+        dest: /etc/systemd/system/opennebula-exporter.service.d/override.conf
+        src: "{{ role_path }}/../common/templates/opennebula-exporter.service.jinja"
+      - name: opennebula-node-exporter.service
+        dest: /etc/systemd/system/opennebula-node-exporter.service.d/override.conf
+        src: "{{ role_path }}/../common/templates/opennebula-node-exporter.service.jinja"
+      - name: opennebula-prometheus.service
+        dest: /etc/systemd/system/opennebula-prometheus.service.d/override.conf
+        src: "{{ role_path }}/../common/templates/opennebula-prometheus.service.jinja"
+  block:
+    - name: Override systemd units (mkdir)
+      ansible.builtin.file:
+        path: "{{ item.dest | dirname }}"
+        state: directory
+        owner: 0
+        group: 0
+        mode: u=rwx,go=rx
+      loop: "{{ _loop }}"
+
+    - name: Override systemd units
+      ansible.builtin.template:
+        dest: "{{ item.dest }}"
+        src: "{{ item.src }}"
+        owner: 0
+        group: 0
+        mode: u=rw,go=r
+      loop: "{{ _loop }}"
+      register: template_override_units
+
+    - name: Enable / Start / Restart Prometheus service and exporters (NOW)
+      ansible.builtin.systemd_service:
+        name: "{{ item.name }}"
+        enabled: true
+        state: >-
+          {{ 'restarted' if _changed else 'started' }}
+        daemon_reload: >-
+          {{ _changed }}
+      loop: "{{ _loop }}"
+      vars:
+        _changed: >-
+          {{ shell_patch_datasources is changed or template_override_units is changed }}


### PR DESCRIPTION
- Allow for modfications of CPUQuota, CPUWeight
- Allow for modfications of MemoryMax, MemoryHigh
- Allow for modfications of IOWeight, IOReadBandwidthMax, IOWriteBandwidthMax
- Provide typical defaults for smaller Prometheus/Grafana clusters
- Make coding style improvements
- Update README.md files