### PR TITLE
F OpenNebula/one-deploy#188: add repo manage flag to make repository role no-op

### DIFF
--- a/roles/repository/README.md
+++ b/roles/repository/README.md
@@ -15,6 +15,7 @@ Role Variables
 |---------------------------------|--------|---------------|---------------------|-----------------------------------------------------------------------|
 | `one_version`                   | `str`  | `6.8`         | `6.8.3`             | OpenNebula version (CE/EE is decided by the presence of `one_token`). |
 | `one_token`                     | `str`  | undefined     | `asd123as:123asd12` | OpenNebula Enterprise Edition subscription token.                     |
+| `repository_manage`            | `bool` | `true`        | `false`             | Disable all repository management in this role globally.              |
 | `repos_enabled`                 | `list` | (check below) | `[frr]`             | Enable installation of specific repos.                                |
 |                                 |        |               |                     |                                                                       |
 | `ceph_repo_force_trusted`       | `bool` | `false`       |                     | Disable Ceph GPG / SSL repo verification.                             |
@@ -52,6 +53,7 @@ Example Playbook
 
     - hosts: frontend:node
       vars:
+        repository_manage: false
         repos_enabled: [ceph, frr, grafana, opennebula] # defaults
 
         # Enable OpenNebula EE repo.

--- a/roles/repository/defaults/main.yml
+++ b/roles/repository/defaults/main.yml
@@ -26,6 +26,7 @@ repo_constraints:
       {{ (groups.get(frontend_group | d('frontend'), []) + groups.get(node_group | d('node'), [])) | unique }}
 
 repos_enabled: [ceph, frr, grafana, opennebula]
+repository_manage: true
 
 ###
 

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -1,30 +1,42 @@
 ---
-- name: Install dependencies (TRY)
-  ansible.builtin.package:
-    name: "{{ _common + _specific[ansible_os_family] }}"
-  vars:
-    _common: [ca-certificates, gnupg2]
-    _specific:
-      Debian: [apt-transport-https, dirmngr, software-properties-common]
-      RedHat: []
-  # NOTE: This allows for some limited recovery if re-executed, it is likely
-  #       required packages are already installed.
-  ignore_errors: true # noqa ignore-errors
+- when: repository_manage | bool
+  block:
+    - name: Install dependencies (TRY)
+      ansible.builtin.package:
+        name: "{{ _common + _specific[ansible_os_family] }}"
+      vars:
+        _common: [ca-certificates, gnupg2]
+        _specific:
+          Debian: [apt-transport-https, dirmngr, software-properties-common]
+          RedHat: []
+      # NOTE: This allows for some limited recovery if re-executed, it is likely
+      #       required packages are already installed.
+      ignore_errors: true # noqa ignore-errors
 
-- ansible.builtin.include_tasks:
-    file: "{{ role_path }}/tasks/{{ _item }}.yml"
-  when:
-    - repo_constraints[_item].condition
-    - inventory_hostname in repo_constraints[_item].hosts
+    - ansible.builtin.include_tasks:
+        file: "{{ role_path }}/tasks/{{ _item }}.yml"
+      when:
+        - repo_constraints[_item].condition
+        - inventory_hostname in repo_constraints[_item].hosts
+      loop: "{{ repos_enabled }}"
+      loop_control: { loop_var: _item }
+
+    - name: Update package manager cache
+      ansible.builtin.package:
+        update_cache: "{{ _changed is any }}"
+      vars:
+        # Gather all existing results from repo config rendering.
+        _changed: >-
+          {{ repos_enabled | map('regex_replace', '^(.*)$', '\g<1>_repo')
+                           | map('extract', hostvars[inventory_hostname], ['changed'])
+                           | map('default', false) }}
+
+- name: Mark repositories as externally managed
+  ansible.builtin.set_fact:
+    "{{ _item }}_repo":
+      changed: false
+      skipped: true
+      repository_manage: false
+  when: repository_manage | bool is false
   loop: "{{ repos_enabled }}"
   loop_control: { loop_var: _item }
-
-- name: Update package manager cache
-  ansible.builtin.package:
-    update_cache: "{{ _changed is any }}"
-  vars:
-    # Gather all existing results from repo config rendering.
-    _changed: >-
-      {{ repos_enabled | map('regex_replace', '^(.*)$', '\g<1>_repo')
-                       | map('extract', hostvars[inventory_hostname], ['changed'])
-                       | map('default', false) }}


### PR DESCRIPTION
**Description**
In some situation we want to delegate the whole repo management logic to an external tool. For this use case the repository_manage flag disables the repository role's behaviour, allowing all the current playbooks and role re-invocations to stay transparent.

**Testing**

1. backward compatibility: after the changes, keeping the inventory unchanged the behaviour is the same (rely on default true value).
2. setting the flag to false: 
```
ansible-playbook -i inventory.yml opennebula.deploy.main --tags "node,preinstall,libvirt" --limit "host11"
[...]
TASK [opennebula.deploy.repository : Install dependencies (TRY)] *****************************************************************************************************
Thursday 19 March 2026  09:38:15 +0000 (0:00:00.062)       0:00:02.476 ******** 
skipping: [nfhhvmadlb11]

TASK [opennebula.deploy.repository : ansible.builtin.include_tasks] **************************************************************************************************
Thursday 19 March 2026  09:38:15 +0000 (0:00:00.031)       0:00:02.508 ******** 
skipping: [nfhhvmadlb11] => (item=ceph) 
skipping: [nfhhvmadlb11] => (item=frr) 
skipping: [nfhhvmadlb11] => (item=grafana) 
skipping: [nfhhvmadlb11] => (item=opennebula) 
skipping: [nfhhvmadlb11]

TASK [opennebula.deploy.repository : Update package manager cache] ***************************************************************************************************
Thursday 19 March 2026  09:38:15 +0000 (0:00:00.049)       0:00:02.557 ******** 
skipping: [nfhhvmadlb11]

TASK [opennebula.deploy.repository : Mark repositories as externally managed] ****************************************************************************************
Thursday 19 March 2026  09:38:15 +0000 (0:00:00.030)       0:00:02.588 ******** 
ok: [nfhhvmadlb11] => (item=ceph)
ok: [nfhhvmadlb11] => (item=frr)
ok: [nfhhvmadlb11] => (item=grafana)
ok: [nfhhvmadlb11] => (item=opennebula)
```

And after these roles verified that no repositories has been added to `host11`.