### PR TITLE
M #-: Add support for openSUSE Leap 16 (OpenNebula 7.2)

### DIFF
--- a/roles/ceph/node/tasks/main.yml
+++ b/roles/ceph/node/tasks/main.yml
@@ -10,6 +10,7 @@
     _specific:
       Debian: [qemu-utils]
       RedHat: [qemu-img]
+      Suse: [qemu-img]
   register: package
   until: package is success
   retries: 12

--- a/roles/ceph/repository/tasks/main.yml
+++ b/roles/ceph/repository/tasks/main.yml
@@ -14,6 +14,7 @@
         _specific:
           Debian: [qemu-utils]
           RedHat: [qemu-img, "centos-release-ceph-{{ ceph.release }}"]
+          Suse: [qemu-img]
       register: package
       until: package is success
       retries: 12
@@ -40,6 +41,7 @@
         _specific:
           Debian: [qemu-utils]
           RedHat: [qemu-img]
+          Suse: [qemu-img]
       register: package
       until: package is success
       retries: 12

--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -14,6 +14,10 @@
       RedHat:
         MariaDB: [mariadb-server]
         SQLite: [sqlite]
+      Suse:
+        MariaDB: [mariadb]
+        SQLite: [sqlite3]
+
   register: package
   until: package is success
   retries: 12
@@ -32,6 +36,8 @@
           Debian:
             MariaDB: mariadb
           RedHat:
+            MariaDB: mariadb
+          Suse:
             MariaDB: mariadb
 
     - name: Create DB instance for OpenNebula

--- a/roles/flow/tasks/main.yml
+++ b/roles/flow/tasks/main.yml
@@ -15,6 +15,7 @@
         _specific:
           Debian: []
           RedHat: []
+          Suse: []
       register: package
       until: package is success
       retries: 12

--- a/roles/form/tasks/main.yml
+++ b/roles/form/tasks/main.yml
@@ -15,6 +15,7 @@
         _specific:
           Debian: []
           RedHat: []
+          Suse: []
       register: package
       until: package is success
       retries: 12

--- a/roles/frr/common/tasks/main.yml
+++ b/roles/frr/common/tasks/main.yml
@@ -11,10 +11,11 @@
       ansible.builtin.package:
         name: "{{ _common + _specific[ansible_os_family] }}"
       vars:
-        _common: [frr, frr-pythontools]
+        _common: [frr]
         _specific:
-          Debian: []
-          RedHat: []
+          Debian: [frr-pythontools]
+          RedHat: [frr-pythontools]
+          Suse: []
       register: package
       until: package is success
       retries: 12
@@ -44,7 +45,7 @@
         enabled: true
         state: >-
           {{ 'restarted'
-              if ((file_frr_conf is changed)
-                  or
-                  (replace_daemons is changed)) else
+             if ((file_frr_conf is changed)
+                 or
+                 (replace_daemons is changed)) else
              'started' }}

--- a/roles/gate/tasks/main.yml
+++ b/roles/gate/tasks/main.yml
@@ -15,6 +15,7 @@
         _specific:
           Debian: []
           RedHat: []
+          Suse: []
       register: package
       until: package is success
       retries: 12

--- a/roles/gui/handlers/main.yml
+++ b/roles/gui/handlers/main.yml
@@ -10,7 +10,7 @@
     name: "{{ _name[ansible_os_family] }}"
     state: reloaded
   vars:
-    _name: { Debian: apache2, RedHat: httpd }
+    _name: { Debian: apache2, RedHat: httpd, Suse: apache2 }
 
 - name: Reload nginx
   ansible.builtin.service:

--- a/roles/gui/tasks/apache.yml
+++ b/roles/gui/tasks/apache.yml
@@ -9,26 +9,66 @@
         _specific:
           Debian: [apache2]
           RedHat: [httpd, mod_ssl]
+          Suse: [apache2]
       register: package
       until: package is success
       retries: 12
       delay: 5
 
     # NOTE: All modules specified below are not enabled automatically
-    #       in Debian-like distros.
-    - name: Enable Apache2 modules
-      ansible.builtin.command:
-        cmd: a2enmod '{{ item }}'
-        creates: "/etc/apache2/mods-enabled/{{ item }}.load"
-      loop: [headers, proxy, proxy_http, proxy_wstunnel, rewrite, ssl]
+    #       in Debian-like and Suse-like distros.
+    - name: Manage Apache2 modules
+      ansible.builtin.shell:
+        cmd: "{{ _shell[ansible_os_family].cmd }}"
+        executable: /bin/bash
+      when:
+        - ansible_os_family in _mods
+        - ansible_os_family in _shell
+      vars:
+        _mods:
+          Debian: [headers, proxy, proxy_http, proxy_wstunnel, rewrite, ssl]
+          Suse: [access_compat, headers, proxy, proxy_http, proxy_wstunnel, rewrite, ssl]
+        _shell:
+          Debian:
+            cmd: |
+              set -o errexit -o pipefail
+              BEFORE="$(a2query -m | sort | cksum)"
+              {% for v in _mods.Debian %}
+              a2enmod '{{ v }}'
+              {% endfor %}
+              AFTER="$(a2query -m | sort | cksum)"
+              if [[ "$AFTER" == "$BEFORE" ]]; then
+                exit 0
+              else
+                exit 78 # EREMCHG
+              fi
+          Suse:
+            cmd: |
+              set -o errexit -o pipefail
+              BEFORE="$(a2enmod -l | sort | cksum)"
+              {% for v in _mods.Suse %}
+              a2enmod '{{ v }}'
+              {% endfor %}
+              a2enflag SSL
+              AFTER="$(a2enmod -l | sort | cksum)"
+              if [[ "$AFTER" == "$BEFORE" ]]; then
+                exit 0
+              else
+                exit 78 # EREMCHG
+              fi
+      register: shell
+      changed_when:
+        - shell.rc in [78]
+      failed_when:
+        - shell.rc not in [0, 78]
       notify:
-        - Restart FireEdge Server
-      when: ansible_os_family == 'Debian'
+        - Reload Apache2
 
 - vars:
     _destdir:
       Debian: /etc/apache2/sites-available
       RedHat: /etc/httpd/conf.d
+      Suse: /etc/apache2/conf.d
     _template: reverse_proxy_ssl_apache2.conf.j2
     _loop:
       - name: opennebula-ssl
@@ -59,16 +99,10 @@
       notify:
         - Reload Apache2
 
-- name: Enable Apache2 Server
-  ansible.builtin.service:
-    name: "{{ _name[ansible_os_family] }}"
-    enabled: true
-  vars:
-    _name: { Debian: apache2, RedHat: httpd }
-
-- name: Start Apache2 Server
-  ansible.builtin.service:
-    name: "{{ _name[ansible_os_family] }}"
-    state: started
-  vars:
-    _name: { Debian: apache2, RedHat: httpd }
+    - name: Enable/Start Apache2 Server
+      ansible.builtin.service:
+        name: "{{ _name[ansible_os_family] }}"
+        enabled: true
+        state: started
+      vars:
+        _name: { Debian: apache2, RedHat: httpd, Suse: apache2 }

--- a/roles/gui/tasks/config.yml
+++ b/roles/gui/tasks/config.yml
@@ -16,3 +16,28 @@
   notify:
     - Restart FireEdge Server
   when: one_token is defined and one_token is truthy
+
+- name: Enable/Persist httpd_can_network_connect
+  ansible.builtin.shell:
+    cmd: |
+      set -o errexit
+      BEFORE="$(getsebool httpd_can_network_connect)"
+      setsebool -P httpd_can_network_connect on
+      AFTER="$(getsebool httpd_can_network_connect)"
+      if [[ "$AFTER" == "$BEFORE" ]]; then
+        exit 0
+      else
+        exit 78 # EREMCHG
+      fi
+    executable: /bin/bash
+  register: shell
+  changed_when:
+    - shell.rc in [78]
+  failed_when:
+    - shell.rc not in [0, 78]
+  when:
+    - ssl.web_server is defined
+    - ssl.web_server is string
+    - ssl.web_server is truthy
+    - ansible_facts.selinux.status is defined
+    - ansible_facts.selinux.status in ['enabled']

--- a/roles/gui/tasks/main.yml
+++ b/roles/gui/tasks/main.yml
@@ -15,6 +15,7 @@
         _specific:
           Debian: []
           RedHat: []
+          Suse: []
       register: package
       until: package is success
       retries: 12

--- a/roles/gui/tasks/nginx.yml
+++ b/roles/gui/tasks/nginx.yml
@@ -9,14 +9,15 @@
       retries: 12
       delay: 5
 
-
 - vars:
     _destdir:
       Debian: /etc/nginx/sites-available
       RedHat: /etc/nginx/conf.d
+      Suse: /etc/nginx/conf.d
     _default_conf_file:
       Debian: /etc/nginx/sites-enabled/default
       RedHat: /etc/nginx/conf.d/default.conf
+      Suse: null
     _template: reverse_proxy_ssl_nginx.conf.j2
     _loop:
       - name: opennebula-ssl
@@ -29,6 +30,7 @@
       ansible.builtin.file:
         path: "{{ _default_conf_file[ansible_os_family] }}"
         state: absent
+      when: _default_conf_file[ansible_os_family] is not none
 
     - name: Configure OpenNebula VHOSTs (nginx)
       ansible.builtin.template:
@@ -52,7 +54,6 @@
       loop: "{{ _loop }}"
       notify:
         - Reload nginx
-
 
 - name: Enable nginx Server
   ansible.builtin.service:

--- a/roles/helper/cache/tasks/main.yml
+++ b/roles/helper/cache/tasks/main.yml
@@ -25,5 +25,6 @@
 
 - name: Update package cache
   ansible.builtin.package:
+    name: []
     update_cache: true
   when: update_pkg_cache | bool is true

--- a/roles/helper/fstab/tasks/main.yml
+++ b/roles/helper/fstab/tasks/main.yml
@@ -9,6 +9,8 @@
         - "{{ 'nfs-common' if ('nfs' in _fstypes) else None }}"
       RedHat:
         - "{{ 'nfs-utils' if ('nfs' in _fstypes) else None }}"
+      Suse:
+        - "{{ 'nfs-client' if ('nfs' in _fstypes) else None }}"
     _fstypes: >-
       {{ fstab | d([])
                | map(attribute='fstype')

--- a/roles/helper/kernel/tasks/params.yml
+++ b/roles/helper/kernel/tasks/params.yml
@@ -35,7 +35,7 @@
           # {mark} managed by one-deploy
         block: |
           . /etc/default/grub.d/99-cmdline.cfg || :
-      when: ansible_os_family in ['RedHat']
+      when: ansible_os_family in ['RedHat', 'Suse']
 
     - name: Ensure /etc/default/grub.d/
       ansible.builtin.file:
@@ -78,6 +78,17 @@
               set -o errexit
               BEFORE="$(cksum /boot/grub2/grub.cfg)"
               grub2-mkconfig -o /boot/grub2/grub.cfg --update-bls-cmdline || grub2-mkconfig -o /boot/grub2/grub.cfg
+              AFTER="$(cksum /boot/grub2/grub.cfg)"
+              if [[ "$AFTER" == "$BEFORE" ]]; then
+                exit 0
+              else
+                exit 78 # EREMCHG
+              fi
+          Suse:
+            cmd: |
+              set -o errexit
+              BEFORE="$(cksum /boot/grub2/grub.cfg)"
+              grub2-mkconfig -o /boot/grub2/grub.cfg
               AFTER="$(cksum /boot/grub2/grub.cfg)"
               if [[ "$AFTER" == "$BEFORE" ]]; then
                 exit 0

--- a/roles/helper/mkfs/tasks/main.yml
+++ b/roles/helper/mkfs/tasks/main.yml
@@ -27,6 +27,15 @@
             swap: util-linux
             vfat: dosfstools
             xfs: xfsprogs
+          Suse:
+            btrfs: btrfsprogs
+            ext2: e2fsprogs
+            ext3: e2fsprogs
+            ext4: e2fsprogs
+            lvm: lvm2
+            swap: util-linux
+            vfat: dosfstools
+            xfs: xfsprogs
         _known: >-
           {%- set output = [] -%}
           {%- for fstype in mkfs | map(attribute='fstype') -%}

--- a/roles/helper/ntp/tasks/main.yml
+++ b/roles/helper/ntp/tasks/main.yml
@@ -13,9 +13,11 @@
       chronyd:
         Debian: chrony.service
         RedHat: chronyd.service
+        Suse: chronyd.service
       timesyncd:
         Debian: systemd-timesyncd.service
         RedHat: systemd-timesyncd.service
+        Suse: systemd-timesyncd.service
     _enabled: >-
       {{ systemd_ntp_services.results | selectattr('status.LoadState', 'defined')
                                       | rejectattr('status.LoadState', 'in', ['masked', 'not-found'])
@@ -42,6 +44,7 @@
         _cfg_dirs:
           Debian: /etc/chrony
           RedHat: /etc
+          Suse: /etc
         _cfg_path: "{{ _cfg_dirs[ansible_os_family] }}/chrony.conf"
       block:
         - name: Ensure /etc/chrony/sources.d
@@ -59,7 +62,7 @@
               # {mark} managed by one-deploy
             block: |
               sourcedir /etc/chrony/sources.d
-          when: ansible_os_family in ['RedHat']
+          when: ansible_os_family in ['RedHat', 'Suse']
 
         - name: Update NTP sources
           ansible.builtin.copy:
@@ -80,7 +83,7 @@
         - name: Cleanup chrony.conf
           ansible.builtin.replace:
             path: "{{ _cfg_path }}"
-            regexp: '^((pool|server|peer)\s.*)$'
+            regexp: '^((pool|server|peer|include)\s.*)$'
             replace: '# \g<1>'
           register: replace_chrony_conf
 

--- a/roles/helper/pci/tasks/devices.yml
+++ b/roles/helper/pci/tasks/devices.yml
@@ -7,6 +7,7 @@
     _specific:
       Debian: []
       RedHat: []
+      Suse: []
   register: package
   until: package is success
   retries: 12

--- a/roles/helper/python3/files/python3.sh
+++ b/roles/helper/python3/files/python3.sh
@@ -12,3 +12,8 @@ if [[ -f /etc/redhat-release ]]; then
     dnf -q install -y python3
     exit
 fi
+
+if [[ -f /etc/SUSE-brand ]]; then
+    zypper --non-interactive install -y python3
+    exit
+fi

--- a/roles/helper/python3/tasks/main.yml
+++ b/roles/helper/python3/tasks/main.yml
@@ -18,6 +18,7 @@
     _specific:
       Debian: [python3-ruamel.yaml]
       RedHat: [python3-ruamel-yaml]
+      Suse: [python3-ruamel.yaml]
   register: package
   until: package is success
   retries: 12

--- a/roles/kvm/tasks/main.yml
+++ b/roles/kvm/tasks/main.yml
@@ -15,6 +15,7 @@
         _specific:
           Debian: []
           RedHat: []
+          Suse: []
       register: package
       until: package is success
       retries: 12

--- a/roles/network/node/tasks/main.yml
+++ b/roles/network/node/tasks/main.yml
@@ -7,6 +7,7 @@
     _managers:
       Debian: [netplan]
       RedHat: [networkmanager]
+      Suse: [networkmanager]
     _phydev: "{{ vn_dict[_item.0].template.PHYDEV }}"
     _bridge: "{{ vn_dict[_item.0].template.BRIDGE }}"
     # Narrow down VNET types when move_ip is unspecified (but allow users to override it still).

--- a/roles/opennebula/server/tasks/main.yml
+++ b/roles/opennebula/server/tasks/main.yml
@@ -15,6 +15,7 @@
         _specific:
           Debian: []
           RedHat: []
+          Suse: []
       register: package
       until: package is success
       retries: 12

--- a/roles/precheck/tasks/ceph.yml
+++ b/roles/precheck/tasks/ceph.yml
@@ -45,6 +45,8 @@
         RedHat:
           '9': [community]
           '10': []
+        openSUSE Leap:
+          '16': []
       tentacle: # Ceph 20.2.z
         Debian:
           '12': [community]
@@ -58,4 +60,6 @@
         RedHat:
           '9': [community]
           '10': []
+        openSUSE Leap:
+          '16': []
   tags: [preinstall]

--- a/roles/precheck/tasks/site.yml
+++ b/roles/precheck/tasks/site.yml
@@ -141,6 +141,7 @@
     _supported:
       - Debian
       - RedHat
+      - Suse
 
 - name: Check if distro is supported
   ansible.builtin.assert:
@@ -150,6 +151,7 @@
       - AlmaLinux
       - Debian
       - RedHat
+      - openSUSE Leap
       - Ubuntu
 
 - name: Check if node_hv is supported

--- a/roles/prometheus/exporter/tasks/main.yml
+++ b/roles/prometheus/exporter/tasks/main.yml
@@ -17,6 +17,7 @@
         _specific:
           Debian: []
           RedHat: []
+          Suse: []
       register: package
       until: package is success
       retries: 12

--- a/roles/prometheus/grafana/tasks/main.yml
+++ b/roles/prometheus/grafana/tasks/main.yml
@@ -15,6 +15,7 @@
         _specific:
           Debian: []
           RedHat: []
+          Suse: []
       register: package
       until: package is success
       retries: 12

--- a/roles/prometheus/server/tasks/main.yml
+++ b/roles/prometheus/server/tasks/main.yml
@@ -18,6 +18,7 @@
         _specific:
           Debian: []
           RedHat: []
+          Suse: []
       register: package
       until: package is success
       retries: 12

--- a/roles/repository/defaults/main.yml
+++ b/roles/repository/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-one_version: '6.10'
+one_version: '7.2'
 
 repo_constraints:
   ceph:
@@ -39,18 +39,22 @@ ceph_repo_url: {}
 ceph_repo_key_path_defaults:
   Debian: /etc/apt/trusted.gpg.d/ceph.asc
   RedHat: /etc/pki/rpm-gpg/RPM-GPG-KEY-ceph
+  Suse: null
 
 ceph_repo_key_url_defaults:
   Debian: https://download.ceph.com/keys/release.asc
   RedHat: https://download.ceph.com/keys/release.asc
+  Suse: null
 
 ceph_repo_path_defaults:
   Debian: /etc/apt/sources.list.d/ceph.list
   RedHat: /etc/yum.repos.d/ceph.repo
+  Suse: null
 
 ceph_repo_url_defaults:
   Debian: https://download.ceph.com/debian-{{ ceph.release }}
   RedHat: https://download.ceph.com/rpm-{{ ceph.release }}
+  Suse: null
 
 ###
 
@@ -64,18 +68,22 @@ frr_repo_url: {}
 frr_repo_key_path_defaults:
   Debian: /etc/apt/trusted.gpg.d/frr.asc
   RedHat: /etc/pki/rpm-gpg/RPM-GPG-KEY-frr
+  Suse: null
 
 frr_repo_key_url_defaults:
   Debian: https://deb.frrouting.org/frr/keys.asc
   RedHat: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x7AB8AC624CBA356CB6216D48F66B5A9140673A87
+  Suse: null
 
 frr_repo_path_defaults:
   Debian: /etc/apt/sources.list.d/frr.list
   RedHat: /etc/yum.repos.d/frr.repo
+  Suse: null
 
 frr_repo_url_defaults:
   Debian: https://deb.frrouting.org/frr
   RedHat: https://rpm.frrouting.org/repo/el$releasever
+  Suse: null
 
 ###
 
@@ -89,18 +97,22 @@ grafana_repo_url: {}
 grafana_repo_key_path_defaults:
   Debian: /etc/apt/trusted.gpg.d/grafana.asc
   RedHat: /etc/pki/rpm-gpg/RPM-GPG-KEY-grafana
+  Suse: /etc/pki/rpm-gpg/RPM-GPG-KEY-grafana
 
 grafana_repo_key_url_defaults:
   Debian: https://apt.grafana.com/gpg.key
   RedHat: https://rpm.grafana.com/gpg.key
+  Suse: https://rpm.grafana.com/gpg.key
 
 grafana_repo_path_defaults:
   Debian: /etc/apt/sources.list.d/grafana.list
   RedHat: /etc/yum.repos.d/grafana.repo
+  Suse: /etc/zypp/repos.d/grafana.repo
 
 grafana_repo_url_defaults:
   Debian: https://apt.grafana.com
   RedHat: https://rpm.grafana.com
+  Suse: https://rpm.grafana.com
 
 ###
 
@@ -114,27 +126,25 @@ opennebula_repo_url: {}
 opennebula_repo_key_path_defaults:
   Debian: /etc/apt/trusted.gpg.d/opennebula2.asc
   RedHat: /etc/pki/rpm-gpg/RPM-GPG-KEY-opennebula2
+  Suse: /etc/pki/rpm-gpg/RPM-GPG-KEY-opennebula2
 
 opennebula_repo_key_url_defaults:
   Debian: https://downloads.opennebula.io/repo/repo2.key
   RedHat: https://downloads.opennebula.io/repo/repo2.key
+  Suse: https://downloads.opennebula.io/repo/repo2.key
 
 opennebula_repo_path_defaults:
   Debian: /etc/apt/sources.list.d/opennebula.list
   RedHat: /etc/yum.repos.d/opennebula.repo
+  Suse: /etc/zypp/repos.d/opennebula.repo
 
 opennebula_repo_url_defaults:
+  # DEB
   Debian: >-
     {%- if one_token is defined and one_token is truthy -%}
       https://{{ one_token }}@enterprise.opennebula.io/repo/{{ one_version }}/{{ ansible_distribution }}/{{ ansible_distribution_major_version }}
     {%- else -%}
       https://downloads.opennebula.io/repo/{{ one_version }}/{{ ansible_distribution }}/{{ ansible_distribution_major_version }}
-    {%- endif -%}
-  RedHat: >-
-    {%- if one_token is defined and one_token is truthy -%}
-      https://{{ one_token }}@enterprise.opennebula.io/repo/{{ one_version }}/{{ ansible_distribution }}
-    {%- else -%}
-      https://downloads.opennebula.io/repo/{{ one_version }}/{{ ansible_distribution }}
     {%- endif -%}
   Ubuntu: >-
     {%- if one_token is defined and one_token is truthy -%}
@@ -142,6 +152,20 @@ opennebula_repo_url_defaults:
     {%- else -%}
       https://downloads.opennebula.io/repo/{{ one_version }}/{{ ansible_distribution }}/{{ ansible_distribution_version }}
     {%- endif -%}
+  # RPM
+  openSUSE Leap: >-
+    {%- if one_token is defined and one_token is truthy -%}
+      https://{{ one_token }}@enterprise.opennebula.io/repo/{{ one_version }}/openSUSE
+    {%- else -%}
+      https://downloads.opennebula.io/repo/{{ one_version }}/openSUSE
+    {%- endif -%}
+  RedHat: >-
+    {%- if one_token is defined and one_token is truthy -%}
+      https://{{ one_token }}@enterprise.opennebula.io/repo/{{ one_version }}/{{ ansible_distribution }}
+    {%- else -%}
+      https://downloads.opennebula.io/repo/{{ one_version }}/{{ ansible_distribution }}
+    {%- endif -%}
+  Suse: null
 
 opennebula_repo_pre_enable_defaults:
   AlmaLinux:
@@ -149,24 +173,45 @@ opennebula_repo_pre_enable_defaults:
       '8': []
       '9': []
       '10': []
-    extra_rpms:
-      '8': []
-      '9': []
-      '10': []
     config_manager:
       '8': [epel, powertools, ha]
       '9': [epel, crb, highavailability]
       '10': [epel, crb, highavailability]
+    extra_repos:
+      '8': []
+      '9': []
+      '10': []
+    extra_rpms:
+      '8': []
+      '9': []
+      '10': []
+  openSUSE Leap:
+    extra_repos:
+      '16':
+        - alias: science
+          uri: https://download.opensuse.org/repositories/science/openSUSE_Leap_16.0/
+        - alias: multimedia
+          uri: https://download.opensuse.org/repositories/multimedia:/apps/16.0/
+        - alias: devel_languages_go
+          uri: https://download.opensuse.org/repositories/devel:/languages:/go/16.0/
+        - alias: nodejs20-16
+          uri: https://download.opensuse.org/repositories/home:/one-infra:/nodejs:/16.0/16.0/
+    extra_rpms:
+      '16': []
   RedHat:
     subscription_manager:
       '8': [codeready-builder-for-rhel-8-x86_64-rpms, rhel-8-for-x86_64-highavailability-rpms]
       '9': [codeready-builder-for-rhel-9-x86_64-rpms, rhel-9-for-x86_64-highavailability-rpms]
       '10': [codeready-builder-for-rhel-10-x86_64-rpms, rhel-10-for-x86_64-highavailability-rpms]
-    extra_rpms:
-      '8': ["https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"]
-      '9': ["https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"]
-      '10': ["https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm"]
     config_manager:
       '8': [epel]
       '9': [epel]
       '10': [epel]
+    extra_repos:
+      '8': []
+      '9': []
+      '10': []
+    extra_rpms:
+      '8': [https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm]
+      '9': [https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm]
+      '10': [https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm]

--- a/roles/repository/tasks/ceph.yml
+++ b/roles/repository/tasks/ceph.yml
@@ -1,5 +1,10 @@
 ---
-- vars:
+- when:
+    - (_repo_key_path[ansible_distribution] | d(_repo_key_path[ansible_os_family])) is not none
+    - (_repo_key_url[ansible_distribution] | d(_repo_key_url[ansible_os_family])) is not none
+    - (_repo_path[ansible_distribution] | d(_repo_path[ansible_os_family])) is not none
+    - (_repo_url[ansible_distribution] | d(_repo_url[ansible_os_family])) is not none
+  vars:
     # Merge repository config with defaults.
     _repo_key_path: "{{ ceph_repo_key_path_defaults | combine(ceph_repo_key_path, recursive=true) }}"
     _repo_key_url: "{{ ceph_repo_key_url_defaults | combine(ceph_repo_key_url, recursive=true) }}"
@@ -29,6 +34,14 @@
                 return_content: true
               run_once: true
               register: uri
+
+            - name: Create directory for GPG keys
+              ansible.builtin.file:
+                dest: "{{ _repo_key_path[ansible_os_family] | trim | dirname }}"
+                state: directory
+                owner: 0
+                group: 0
+                mode: u=rwx,g=rx
 
             - name: Install Ceph GPG key
               ansible.builtin.copy:
@@ -83,4 +96,5 @@
             gpgcheck=0
             sslverify=0
             {% endif %}
+          Suse: null
       register: ceph_repo

--- a/roles/repository/tasks/frr.yml
+++ b/roles/repository/tasks/frr.yml
@@ -1,5 +1,10 @@
 ---
-- vars:
+- when:
+    - (_repo_key_path[ansible_distribution] | d(_repo_key_path[ansible_os_family])) is not none
+    - (_repo_key_url[ansible_distribution] | d(_repo_key_url[ansible_os_family])) is not none
+    - (_repo_path[ansible_distribution] | d(_repo_path[ansible_os_family])) is not none
+    - (_repo_url[ansible_distribution] | d(_repo_url[ansible_os_family])) is not none
+  vars:
     # Merge repository config with defaults.
     _repo_key_path: "{{ frr_repo_key_path_defaults | combine(frr_repo_key_path, recursive=true) }}"
     _repo_key_url: "{{ frr_repo_key_url_defaults | combine(frr_repo_key_url, recursive=true) }}"
@@ -29,6 +34,14 @@
                 return_content: true
               run_once: true
               register: uri
+
+            - name: Create directory for GPG keys
+              ansible.builtin.file:
+                dest: "{{ _repo_key_path[ansible_os_family] | trim | dirname }}"
+                state: directory
+                owner: 0
+                group: 0
+                mode: u=rwx,g=rx
 
             - name: Install Free Range Routing GPG key
               ansible.builtin.copy:
@@ -81,4 +94,5 @@
             gpgcheck=0
             sslverify=0
             {% endif %}
+          Suse: null
       register: frr_repo

--- a/roles/repository/tasks/grafana.yml
+++ b/roles/repository/tasks/grafana.yml
@@ -1,5 +1,10 @@
 ---
-- vars:
+- when:
+    - (_repo_key_path[ansible_distribution] | d(_repo_key_path[ansible_os_family])) is not none
+    - (_repo_key_url[ansible_distribution] | d(_repo_key_url[ansible_os_family])) is not none
+    - (_repo_path[ansible_distribution] | d(_repo_path[ansible_os_family])) is not none
+    - (_repo_url[ansible_distribution] | d(_repo_url[ansible_os_family])) is not none
+  vars:
     # Merge repository config with defaults.
     _repo_key_path: "{{ grafana_repo_key_path_defaults | combine(grafana_repo_key_path, recursive=true) }}"
     _repo_key_url: "{{ grafana_repo_key_url_defaults | combine(grafana_repo_key_url, recursive=true) }}"
@@ -29,6 +34,14 @@
                 return_content: true
               run_once: true
               register: uri
+
+            - name: Create directory for GPG keys
+              ansible.builtin.file:
+                dest: "{{ _repo_key_path[ansible_os_family] | trim | dirname }}"
+                state: directory
+                owner: 0
+                group: 0
+                mode: u=rwx,g=rx
 
             - name: Install Grafana GPG key
               ansible.builtin.copy:
@@ -60,6 +73,21 @@
             gpgkey=file://{{ _repo_key_path.RedHat | trim }}
             sslverify=1
             sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+            {% else %}
+            repo_gpgcheck=0
+            gpgcheck=0
+            sslverify=0
+            {% endif %}
+          Suse: |
+            [grafana]
+            name=grafana
+            baseurl={{ _repo_url.Suse | trim }}
+            enabled=1
+            {% if grafana_repo_force_trusted | bool is false %}
+            repo_gpgcheck=1
+            gpgcheck=1
+            gpgkey=file://{{ _repo_key_path.Suse | trim }}
+            sslverify=1
             {% else %}
             repo_gpgcheck=0
             gpgcheck=0

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -8,13 +8,14 @@
       ansible.builtin.package:
         name: "{{ _common + (_specific[_d][_v] | d(_default[_f])) }}"
       vars:
-        _common: [ca-certificates, gnupg2]
+        _common: [ca-certificates]
         _specific:
           Debian:
-            '13': [apt-transport-https, dirmngr]
+            '13': [apt-transport-https, dirmngr, gnupg2]
         _default:
-          Debian: [apt-transport-https, dirmngr, software-properties-common]
-          RedHat: []
+          Debian: [apt-transport-https, dirmngr, gnupg2, software-properties-common]
+          RedHat: [gnupg2]
+          Suse: [gpg2]
         _d: "{{ ansible_distribution }}"
         _v: "{{ ansible_distribution_major_version }}"
         _f: "{{ ansible_os_family }}"
@@ -32,6 +33,7 @@
 
     - name: Update package manager cache
       ansible.builtin.package:
+        name: []
         update_cache: "{{ _changed is any }}"
       vars:
         # Gather all existing results from repo config rendering.

--- a/roles/repository/tasks/opennebula.yml
+++ b/roles/repository/tasks/opennebula.yml
@@ -1,44 +1,81 @@
 ---
-- when: ansible_pkg_mgr == 'dnf'
+- when: ansible_pkg_mgr in ['dnf', 'zypper']
   block:
-    - name: Compute facts (DNF)
+    - name: Compute facts
       ansible.builtin.set_fact:
         opennebula_repo_pre_enable: >-
           {{ opennebula_repo_pre_enable_defaults | combine(opennebula_repo_pre_enable | d({}), recursive=true) }}
 
-    - name: Enable required DNF extra repos
+    - name: Enable required extra repos
       ansible.builtin.shell:
-        cmd: |
-          set -o errexit
-
-          {% if _subscription_manager | count > 0 %}
-          subscription-manager repos {{ _subscription_manager | map('regex_replace', '^(.*)$', "--enable '\g<1>'") | join(' ') }}
-          {% endif %}
-
-          {% if _extra_rpms | count > 0 %}
-          dnf install -y {{ _extra_rpms | map('regex_replace', '^(.*)$', "'\g<1>'") | join(' ') }}
-          {% endif %}
-
-          {% if _config_manager | count > 0 %}
-          dnf config-manager -y --enable {{ _config_manager | map('regex_replace', '^(.*)$', "'\g<1>'") | join(' ') }}
-          {% endif %}
+        cmd: "{{ _cmd[ansible_os_family].cmd }}"
         executable: /bin/bash
       changed_when: false
       vars:
+        _cmd:
+          RedHat:
+            cmd: |
+              set -o errexit
+
+              {% if _subscription_manager | count > 0 %}
+              subscription-manager repos {{ _subscription_manager | map('regex_replace', '^(.*)$', "--enable '\g<1>'") | join(' ') }}
+              {% endif %}
+
+              {% for v in _extra_repos %}
+              dnf config-manager --add-repo '{{ v.uri }}'
+              {% endfor %}
+
+              {% if _extra_rpms | count > 0 %}
+              dnf install -y {{ _extra_rpms | map('regex_replace', '^(.*)$', "'\g<1>'") | join(' ') }}
+              {% endif %}
+
+              {% if _config_manager | count > 0 %}
+              dnf config-manager -y --enable {{ _config_manager | map('regex_replace', '^(.*)$', "'\g<1>'") | join(' ') }}
+              {% endif %}
+          Suse:
+            cmd: |
+              set -o errexit
+
+              {% if _extra_repos | count > 0 %}
+              REFRESH=false
+              {% for v in _extra_repos %}
+              if ! zypper repos '{{ v.alias }}' 2>/dev/null; then
+                zypper --non-interactive --gpg-auto-import-keys addrepo '{{ v.uri }}' '{{ v.alias }}'
+                REFRESH=true
+              fi
+              {% endfor %}
+              if [[ "$REFRESH" == true ]]; then
+                zypper --non-interactive --gpg-auto-import-keys refresh
+              fi
+              {% endif %}
+
+              {% if _extra_rpms | count > 0 %}
+              zypper --non-interactive --gpg-auto-import-keys install -y {{ _extra_rpms | map('regex_replace', '^(.*)$', "'\g<1>'") | join(' ') }}
+              {% endif %}
+        # RedHat
         _subscription_manager: >-
           {{ opennebula_repo_pre_enable[ansible_distribution].subscription_manager[ansible_distribution_major_version]
-             | d([])
-             | map('replace', "'", '') }}
-        _extra_rpms: >-
-          {{ opennebula_repo_pre_enable[ansible_distribution].extra_rpms[ansible_distribution_major_version]
              | d([])
              | map('replace', "'", '') }}
         _config_manager: >-
           {{ opennebula_repo_pre_enable[ansible_distribution].config_manager[ansible_distribution_major_version]
              | d([])
              | map('replace', "'", '') }}
+        # Common
+        _extra_repos: >-
+          {{ opennebula_repo_pre_enable[ansible_distribution].extra_repos[ansible_distribution_major_version]
+             | d([]) }}
+        _extra_rpms: >-
+          {{ opennebula_repo_pre_enable[ansible_distribution].extra_rpms[ansible_distribution_major_version]
+             | d([])
+             | map('replace', "'", '') }}
 
-- vars:
+- when:
+    - (_repo_key_path[ansible_distribution] | d(_repo_key_path[ansible_os_family])) is not none
+    - (_repo_key_url[ansible_distribution] | d(_repo_key_url[ansible_os_family])) is not none
+    - (_repo_path[ansible_distribution] | d(_repo_path[ansible_os_family])) is not none
+    - (_repo_url[ansible_distribution] | d(_repo_url[ansible_os_family])) is not none
+  vars:
     # Merge repository config with defaults.
     _repo_key_path: "{{ opennebula_repo_key_path_defaults | combine(opennebula_repo_key_path, recursive=true) }}"
     _repo_key_url: "{{ opennebula_repo_key_url_defaults | combine(opennebula_repo_key_url, recursive=true) }}"
@@ -69,6 +106,14 @@
               run_once: true
               register: uri
 
+            - name: Create directory for GPG keys
+              ansible.builtin.file:
+                dest: "{{ _repo_key_path[ansible_os_family] | trim | dirname }}"
+                state: directory
+                owner: 0
+                group: 0
+                mode: u=rwx,g=rx
+
             - name: Install OpenNebula GPG key
               ansible.builtin.copy:
                 dest: "{{ _repo_key_path[ansible_os_family] | trim }}"
@@ -82,11 +127,34 @@
         content: "{{ _content[ansible_distribution] | d(_content[ansible_os_family]) }}"
       vars:
         _content:
+          # DEB
           Debian: |
             {% if opennebula_repo_force_trusted | bool is false %}
             deb {{ _repo_url.Debian | trim }} stable opennebula
             {% else %}
             deb [trusted=yes] {{ _repo_url.Debian | trim }} stable opennebula
+            {% endif %}
+          Ubuntu: |
+            {% if opennebula_repo_force_trusted | bool is false %}
+            deb {{ _repo_url.Ubuntu | trim }} stable opennebula
+            {% else %}
+            deb [trusted=yes] {{ _repo_url.Ubuntu | trim }} stable opennebula
+            {% endif %}
+          # RPM
+          openSUSE Leap: |
+            [opennebula]
+            name=OpenNebula {{ _edition }} Edition
+            baseurl={{ _repo_url['openSUSE Leap'] | trim }}/$releasever_major/$basearch
+            enabled=1
+            {% if opennebula_repo_force_trusted | bool is false %}
+            repo_gpgcheck=1
+            gpgcheck=1
+            gpgkey=file://{{ _repo_key_path['openSUSE Leap'] | trim }}
+            sslverify=1
+            {% else %}
+            repo_gpgcheck=0
+            gpgcheck=0
+            sslverify=0
             {% endif %}
           RedHat: |
             [opennebula]
@@ -104,12 +172,7 @@
             gpgcheck=0
             sslverify=0
             {% endif %}
-          Ubuntu: |
-            {% if opennebula_repo_force_trusted | bool is false %}
-            deb {{ _repo_url.Ubuntu | trim }} stable opennebula
-            {% else %}
-            deb [trusted=yes] {{ _repo_url.Ubuntu | trim }} stable opennebula
-            {% endif %}
+          Suse: null
         _edition: >-
           {{ 'Enterprise' if (one_token is defined and one_token is truthy) else 'Community' }}
       register: opennebula_repo


### PR DESCRIPTION
- Add openSUSE to repository role
- Add opennebula_repo_pre_enable.extra_repos feature
- Adjust ceph, frr, grafana, opennebula repos for openSUSE Leap 16
- Adjust helper roles
- Refactor apache/nginx module handling
- Automatically set httpd_can_network_connect=on (SELinux)
- Adjust multiple package module invocations
- Add 'name: []' to package.update_cache invocations (fix)