### PR TITLE
gui role templates: Remove max file size constraint to prevent upload issues

### DIFF
--- a/roles/gui/templates/reverse_proxy_ssl_apache2.conf.j2
+++ b/roles/gui/templates/reverse_proxy_ssl_apache2.conf.j2
@@ -19,6 +19,11 @@
   ProxyRequests     off
   ProxyPreserveHost on
 
+  # Adjust timeout & file size constraints
+  LimitRequestBody 0
+  Timeout 600
+  ProxyTimeout 600
+
   # no proxy for /error/ (Apache HTTPd errors messages)
   ProxyPass /error/ !
 

--- a/roles/gui/templates/reverse_proxy_ssl_nginx.conf.j2
+++ b/roles/gui/templates/reverse_proxy_ssl_nginx.conf.j2
@@ -20,6 +20,14 @@ server {
         # No squealing.
         server_tokens off;
 
+        # Adjust timeout & file size constraints
+        proxy_connect_timeout 600s;
+        proxy_read_timeout    600s;
+        proxy_send_timeout    600s;
+        client_body_timeout   600s;
+        send_timeout          600s;
+        client_max_body_size  0;
+
         # Redirect root to /fireedge
         location = / {
                 return 301 $scheme://$http_host/fireedge;


### PR DESCRIPTION
**Description**

Update apache and nginx templates
Remove max file size constraint and edit default timeouts to prevent issues when uploading large files to Sunstone

Note:
F OpenNebula/engineering#768: move "Update apache and nginx templates…" commit from fork, where it had the following commit data: 
```
    commit 6439c1dd0b66a623966ba7a8196a6bd48ad055de
    Author: Alejandro Mosteiro <amosteiro@opennebula.io>
    Date:   Tue Feb 24 15:57:23 2026 +0100
        M #-: Update apache and nginx templates
        Remove max file size constraint and edit default timeouts to prevent issues when uploading large files to Sunstone
```

cc @Aletibazo     
