### PR TITLE
Extend kvm role to execute without Frontend

### DIFF
--- a/roles/kvm/tasks/main.yml
+++ b/roles/kvm/tasks/main.yml
@@ -33,11 +33,13 @@
     path: /var/lib/one/.ssh/id_rsa.pub
   register: slurp
   delegate_to: "{{ leader }}"
+  tags: [add_node_to_opennebula]
 
 - name: Add oneadmin's pubkey to authorized keys
   ansible.posix.authorized_key:
     user: oneadmin
     key: "{{ slurp.content | b64decode }}"
+  tags: [add_node_to_opennebula]
 
 - delegate_to: "{{ leader }}"
   block:
@@ -69,3 +71,4 @@
       until: shell is success
       retries: 12
       delay: 5
+  tags: [add_node_to_opennebula]


### PR DESCRIPTION
Move "add tags to KVM role" commit from forked repo.

Original commit in the fork

```
    commit d39902363fb08b7618f3452661ff57ee188d1615
    Author: Alejandro Mosteiro <amosteiro@opennebula.io>
    Date:   Thu Feb 5 13:28:22 2026 +0100

    M #-: Add tags to KVM role
    Add tags the SSH slurp and adding host to OpenNebula tasks, this way it is possible to run KVM role without a Frontend
```