### PR TITLE
M #-: Allow installation of ruamel.yaml via pip

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -1,2 +1,0 @@
----
-ansible_python_interpreter: /usr/bin/python3

--- a/roles/helper/python3/README.md
+++ b/roles/helper/python3/README.md
@@ -11,7 +11,11 @@ N/A
 Role Variables
 --------------
 
-N/A
+| Name                         | Type   | Default               | Example       | Description                                        |
+|------------------------------|--------|-----------------------|---------------|----------------------------------------------------|
+| `ansible_python_interpreter` | `str`  | `/usr/bin/python3`    | (check below) | Ansible's built-in, please refer to official docs. |
+| `python3_os_packages`        | `list` | (check role defaults) | (check below) | Extra python3 OS packages to install.              |
+| `python3_pip_packages`       | `list` | (check role defaults) | (check below) | Extra python3 PyPI packages to install.            |
 
 Dependencies
 ------------
@@ -23,8 +27,23 @@ Example Playbook
 
     - hosts: frontend:node
       strategy: linear
+      vars:
+        ansible_python_interpreter: /usr/bin/python3.11
+        python3_os_packages:
+          Debian: []
+          openSUSE Leap: []
+          RedHat: []
+          Suse: [python311-pip]
+        python3_pip_packages:
+          Debian: []
+          openSUSE Leap: []
+          RedHat: []
+          Suse: [ruamel.yaml]
       roles:
-         - role: opennebula.deploy.helper.python3
+        - role: opennebula.deploy.helper.python3 # install interpreter only
+        - role: opennebula.deploy.helper.facts   # provide the 'setup' fact
+        - role: opennebula.deploy.helper.cache
+        - role: opennebula.deploy.helper.python3 # install packages only
 
 License
 -------

--- a/roles/helper/python3/defaults/main.yml
+++ b/roles/helper/python3/defaults/main.yml
@@ -1,0 +1,53 @@
+---
+python3_os_packages:
+  Debian:
+    - >-
+      {{ 'python3-ruamel.yaml'
+         if (ansible_python_interpreter | basename) == 'python3' else
+         None }}
+    - >-
+      {{ ((ansible_python_interpreter | basename) ~ '-pip')
+         if (python3_pip_packages.Debian | select | count > 0) else
+         None }}
+  openSUSE Leap:
+    - >-
+      {{ 'python3-ruamel.yaml'
+         if (ansible_python_interpreter | basename) == 'python3' else
+         None }}
+    - >-
+      {{ ((ansible_python_interpreter | basename) ~ '-pip')
+         if (python3_pip_packages['openSUSE Leap'] | select | count > 0) else
+         None }}
+  RedHat:
+    - >-
+      {{ 'python3-ruamel-yaml'
+         if (ansible_python_interpreter | basename) == 'python3' else
+         None }}
+    - >-
+      {{ ((ansible_python_interpreter | basename) ~ '-pip')
+         if (python3_pip_packages.RedHat | select | count > 0) else
+         None }}
+  Suse:
+    - >-
+      {{ ((ansible_python_interpreter | basename | replace('.', '')) ~ '-pip')
+         if (python3_pip_packages.Suse | select | count > 0) else
+         None }}
+
+python3_pip_packages:
+  Debian:
+    - >-
+      {{ 'ruamel.yaml'
+         if (ansible_python_interpreter | basename) != 'python3' else
+         None }}
+  openSUSE Leap:
+    - >-
+      {{ 'ruamel.yaml'
+         if (ansible_python_interpreter | basename) != 'python3' else
+         None }}
+  RedHat:
+    - >-
+      {{ 'ruamel.yaml'
+         if (ansible_python_interpreter | basename) != 'python3' else
+         None }}
+  Suse:
+    - ruamel.yaml

--- a/roles/helper/python3/files/python3.sh
+++ b/roles/helper/python3/files/python3.sh
@@ -1,19 +1,22 @@
 #!/usr/bin/env bash
 
+: "${PYTHON3:=python3}"
+: "${PYTHON3_NO_DOTS:=${PYTHON3//.}}"
+
 set -o errexit
 set -x
 
 if [[ -f /etc/debian_version ]]; then
-    DEBIAN_FRONTEND=noninteractive apt-get -q install -y python3
+    DEBIAN_FRONTEND=noninteractive apt-get -q install -y "$PYTHON3"
     exit
 fi
 
 if [[ -f /etc/redhat-release ]]; then
-    dnf -q install -y python3
+    dnf -q install -y "$PYTHON3"
     exit
 fi
 
 if [[ -f /etc/SUSE-brand ]]; then
-    zypper --non-interactive install -y python3
+    zypper --non-interactive install -y "$PYTHON3_NO_DOTS"
     exit
 fi

--- a/roles/helper/python3/meta/main.yml
+++ b/roles/helper/python3/meta/main.yml
@@ -1,3 +1,5 @@
 ---
 collections:
   - opennebula.deploy
+
+allow_duplicates: true

--- a/roles/helper/python3/tasks/main.yml
+++ b/roles/helper/python3/tasks/main.yml
@@ -1,26 +1,46 @@
 ---
-- name: Bootstrap python3 intepreter
-  ansible.builtin.script:
-    cmd: python3.sh
-    executable: /bin/bash
-    creates: /usr/bin/python3
-  register: script
-  until: script is success
-  retries: 12
-  delay: 5
-  when: setup is undefined
+- name: Forcefully (re)define ansible_python_interpreter
+  ansible.builtin.set_fact:
+    ansible_python_interpreter: >-
+      {{ ansible_python_interpreter | d('/usr/bin/python3') }}
 
-- name: Install required python3 packages
-  ansible.builtin.package:
-    name: "{{ _common + _specific[ansible_os_family] }}"
+- when: setup is undefined
+  block:
+    - name: Bootstrap python3 intepreter
+      ansible.builtin.script:
+        cmd: python3.sh
+        executable: /bin/bash
+        creates: "{{ ansible_python_interpreter }}"
+      environment:
+        PYTHON3: "{{ ansible_python_interpreter | basename }}"
+      register: script
+      until: script is success
+      retries: 12
+      delay: 5
+
+- when: setup is defined
   vars:
-    _common: []
-    _specific:
-      Debian: [python3-ruamel.yaml]
-      RedHat: [python3-ruamel-yaml]
-      Suse: [python3-ruamel.yaml]
-  register: package
-  until: package is success
-  retries: 12
-  delay: 5
-  when: setup is defined
+    _python3_os_packages: >-
+      {{ python3_os_packages[_d] | d(python3_os_packages[_f]) | select }}
+    _python3_pip_packages: >-
+      {{ python3_pip_packages[_d] | d(python3_pip_packages[_f]) | select }}
+    _d: "{{ ansible_distribution }}"
+    _f: "{{ ansible_os_family }}"
+  block:
+    - name: Install python3 packages
+      ansible.builtin.package:
+        name: "{{ _python3_os_packages }}"
+      register: package
+      until: package is success
+      retries: 12
+      delay: 5
+      when: _python3_os_packages | count > 0
+
+    - name: Install python3 packages (pip)
+      ansible.builtin.pip:
+        name: "{{ _python3_pip_packages }}"
+      register: pip
+      until: pip is success
+      retries: 12
+      delay: 5
+      when: _python3_pip_packages | count > 0


### PR DESCRIPTION
- Remove hardcoded ansible_python_interpreter from group_vars
- Add missing allow_duplicates meta setting (fix)
- Introduce generic way to install python3 packages via pip
- Auto-install pip for custom intepreters when needed (when unconfigured)
- Auto-install ruamel.yaml via pip for custom intepreters (when unconfigured)
- Anticipate SLES15 support