### PR TITLE
M #-: Propagate python interpreter to dynamically added hosts (fix)

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -9,7 +9,7 @@ ceph_defaults:
   pool: one
   user: libvirt
   host: >-
-    {{ groups[mon_group_name | d('mons')] | map('extract', hostvars, ['ansible_host']) | join(d = ' ')
+    {{ groups[mon_group_name | d('mons')] | map('extract', hostvars, ['ansible_host']) | join(' ')
        if groups[mon_group_name | d('mons')] is defined else
        [] }}
   uuid: null

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -25,6 +25,9 @@
       master_user: >-
         {{ hostvars[_master].ansible_user }}
       master: master # inventory name
+    # Forcefully (re)define ansible_python_interpreter.
+    ansible_python_interpreter: >-
+      {{ ansible_python_interpreter | d('/usr/bin/python3') }}
   vars:
     _master: >-
       {{ groups[_federation_group] | d(groups[_frontend_group]) | first }}
@@ -42,6 +45,7 @@
     name: master
     ansible_host: "{{ federation.master_host }}"
     ansible_user: "{{ federation.master_user }}"
+    ansible_python_interpreter: "{{ ansible_python_interpreter }}"
   changed_when: false
   when:
     - federation.role != 'STANDALONE'

--- a/roles/helper/python3/meta/main.yml
+++ b/roles/helper/python3/meta/main.yml
@@ -2,4 +2,7 @@
 collections:
   - opennebula.deploy
 
+dependencies:
+  - role: opennebula.deploy.common
+
 allow_duplicates: true

--- a/roles/helper/python3/tasks/main.yml
+++ b/roles/helper/python3/tasks/main.yml
@@ -1,8 +1,6 @@
 ---
-- name: Forcefully (re)define ansible_python_interpreter
-  ansible.builtin.set_fact:
-    ansible_python_interpreter: >-
-      {{ ansible_python_interpreter | d('/usr/bin/python3') }}
+# NOTE: Assignment of ansible_python_interpreter variable has been moved to
+#       opennebula.deploy.common role.
 
 - when: setup is undefined
   block:

--- a/roles/opennebula/leader/tasks/main.yml
+++ b/roles/opennebula/leader/tasks/main.yml
@@ -10,15 +10,6 @@
         retry_no: >-
           {{ retry_no | d(6, true) | int - 1 }}
 
-    # When delegate_to's argument is unreachable, then a fatal error
-    # is thrown. It seems this error cannot be rescued in block/rescue/always,
-    # thus we need to check if the Leader is reachable before delegating.
-    - name: Ping the Leader
-      ansible.builtin.wait_for:
-        host: "{{ hostvars[leader].ansible_host | d(leader) }}"
-        port: "{{ ping_port | int }}"
-        timeout: 10
-
     # This check makes sense only when HA mode is enabled.
     - when: (federation.groups.frontend | count > 1)
             or
@@ -35,12 +26,23 @@
             name: leader
             ansible_host: "{{ hostvars[_leader].ansible_host | d(_leader) }}"
             ansible_user: "{{ hostvars[_federation.groups.frontend[0]].ansible_user }}"
+            ansible_python_interpreter: >-
+              {{ hostvars[_federation.groups.frontend[0]].ansible_python_interpreter }}
           changed_when: false
           when: _leader is defined
           vars:
             _leader: "{{ hostvars[item].leader }}"
             _federation: "{{ hostvars[item].federation }}"
           loop: "{{ ansible_play_batch }}"
+
+        # When delegate_to's argument is unreachable, then a fatal error
+        # is thrown. It seems this error cannot be rescued in block/rescue/always,
+        # thus we need to check if the Leader is reachable before delegating.
+        - name: Ping the Leader
+          ansible.builtin.wait_for:
+            host: "{{ hostvars.leader.ansible_host }}"
+            port: "{{ ping_port | int }}"
+            timeout: 10
 
         - name: Get Zone
           ansible.builtin.shell:


### PR DESCRIPTION
- Move assignment of ansible_python_interpreter to common role (global)
- Optimize opennebula/leader role (run wait_for only in HA mode)
- Ensure ansible_python_interpreter is set for leader and master hosts