### PR TITLE
F #183: Add ability to rename net/pci/vfio devices

### DIFF
--- a/plugins/test/main.py
+++ b/plugins/test/main.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+import fnmatch
+import re
+
+class TestModule(object):
+    def tests(self):
+        return {
+            'match_address': self.match_address,
+        }
+
+    # NOTE: It does not validate character classes or character count!
+    # EXAMPLES:
+    # pci -> match_address('0000:0*:00.*', sep='[:.]')
+    # mac -> match_address('52:54:*:*:*:0*', sep='[:]')
+    def match_address(self, address, pattern, sep=None):
+        """Tests if a split string matches a set of simple glob patterns."""
+
+        # In case no separator is provided simply match the whole string.
+        if sep is None:
+            return fnmatch.fnmatch(address, pattern)
+
+        # Make sure both address and pattern contain identical separators.
+        if re.findall(sep, address) != re.findall(sep, pattern):
+            return False
+
+        # Try matching (glob) each segment separately.
+        for x, y in zip(re.split(sep, address), re.split(sep, pattern)):
+            if not fnmatch.fnmatch(x, y):
+                return False
+
+        return True

--- a/plugins/test/match_address.yml
+++ b/plugins/test/match_address.yml
@@ -1,0 +1,43 @@
+---
+# Copyright: OpenNebula Project, OpenNebula Systems
+# Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+
+DOCUMENTATION:
+  name: match_address
+  short_description: Apply glob patterns to a generic address.
+  description:
+    - Tests if a split string matches a set of simple glob patterns.
+  options:
+    _input:
+      description:
+        - An address to match.
+      type: string
+      required: true
+    sep:
+      description:
+        - A regex expression used to split the input string (optional).
+      type: string
+      required: false
+  author:
+    - Michal Opala (@sk4zuzu)
+
+EXAMPLES: |
+  - name: Match MAC address
+    ansible.builtin.debug:
+      msg: >-
+        {{ '12:34:56:78:90:ab' is opennebula.deploy.match_address('12:34:56:78:90:*', sep='[:]') }}
+
+  - name: Select matching PCI addresses
+    ansible.builtin.debug:
+      msg: >-
+        {{ _addresses | select('opennebula.deploy.match_address', '0000:03:00.*', sep='[:.]') }}
+    vars:
+      _addresses:
+        - '12:34:56:78:90:ab' # MAC (skipped)
+        - '0000:03:00.4'      # PCI (matched)
+        - '0000:04:00.0'      # PCI (skipped)
+
+RETURN:
+  _value:
+    description: Returns True if the check passes.
+    type: boolean

--- a/roles/helper/pci/README.md
+++ b/roles/helper/pci/README.md
@@ -11,10 +11,9 @@ N/A
 Role Variables
 --------------
 
-| Name                      | Type   | Default | Example       | Description                     |
-|---------------------------|--------|---------|---------------|---------------------------------|
-| `pci_passthrough_enabled` | `bool` | `false` |               | Enable/Disable PCI passthrough. |
-| `pci_devices`             | `list` | `[]`    | (check below) | PCI devices configuration.      |
+| Name          | Type   | Default | Example       | Description                     |
+|---------------|--------|---------|---------------|---------------------------------|
+| `pci_devices` | `list` | `[]`    | (check below) | PCI devices configuration.      |
 
 Dependencies
 ------------
@@ -26,10 +25,12 @@ Example Playbook
 
     - hosts: node
       vars:
-        pci_passthrough_enabled: true
         pci_devices:
           - address: "0000:02:00.0"
             excluded: true
+          - address: "0000:03:00.*"
+            unlisted: true
+            set_name: "asd{0[3]}"
           - vendor: "1af4"
             device: "*"
             class: "0200"

--- a/roles/helper/pci/README.md
+++ b/roles/helper/pci/README.md
@@ -11,9 +11,18 @@ N/A
 Role Variables
 --------------
 
-| Name          | Type   | Default | Example       | Description                     |
-|---------------|--------|---------|---------------|---------------------------------|
-| `pci_devices` | `list` | `[]`    | (check below) | PCI devices configuration.      |
+| Name                        | Type  | Default   | Example       | Description                                                                  |
+|-----------------------------|-------|-----------|---------------|------------------------------------------------------------------------------|
+| `pci_devices`               | `list`| `[]`      | (check below) | PCI devices configuration.                                                   |
+| `pci_devices[*].excluded`   | `bool`| `false`   | (check below) | Do not process matching PCI devices.                                         |
+| `pci_devices[*].unlisted`   | `bool`| `false`   | (check below) | Do not pass matching PCI devices to OpenNebula.                              |
+| `pci_devices[*].address`    | `str` | undefined | (check below) | Glob PCI devices by PCI or MAC address.                                      |
+| `pci_devices[*].vendor`     | `str` | `*`       | (check below) | Glob PCI devices by PCI Vendor (if address is undefined).                    |
+| `pci_devices[*].device`     | `str` | `*`       | (check below) | Glob PCI devices by PCI Device (if address is undefined).                    |
+| `pci_devices[*].class`      | `str` | `*`       | (check below) | Glob PCI devices by PCI Class (if address is undefined).                     |
+| `pci_devices[*].set_driver` | `str` | `omit`    | (check below) | Use driverctl to override driver (unless "omit").                            |
+| `pci_devices[*].set_name`   | `str` | `omit`    | (check below) | Rename device in udev (unless "omit").                                       |
+| `pci_devices[*].set_numvfs` | `str` | `0`       | (check below) | Enable Virtual Functions for SR-IOV capable devices (integer >= 0 or "max"). |
 
 Dependencies
 ------------
@@ -23,19 +32,77 @@ N/A
 Example Playbook
 ----------------
 
+    # NOTE: Dicts defined in pci_devices are processed top-to-bottom without merging.
+
     - hosts: node
       vars:
         pci_devices:
-          - address: "0000:02:00.0"
-            excluded: true
-          - address: "0000:03:00.*"
-            unlisted: true
-            set_name: "asd{0[3]}"
+          # Rename virtio-net-pci devices unless configured otherwise later (below).
           - vendor: "1af4"
             device: "*"
             class: "0200"
-            set_driver: omit # NOTE: 'vfio-pci' is the default, 'omit' skips override altogether
+            # NOTE: 0[0] -> PCI Domain
+            #       0[1] -> PCI Bus
+            #       0[2] -> PCI Device
+            #       0[3] -> PCI Function
+            set_name: "asd{0[1]}v{0[3]}"
+
+          # Do not rename "0000:04:00.0" + If it's SR-IOV capable, enable all available VFs.
+          - address: "0000:04:00.0"
             set_numvfs: max
+      roles:
+        - role: opennebula.deploy.helper.facts
+        - role: opennebula.deploy.helper.pci
+
+    - hosts: node
+      vars:
+        pci_devices:
+          # Exclude primary NIC from processing.
+          - address: "0000:02:00.0"
+            excluded: true
+
+          # Enable 2 VFs and rename them to asd3v1, asd3v2 + Make sure OpenNebula doesn't use them (unlisted <- true).
+          - address: "0000:03:00.*"
+            set_name: "asd3v{0[3]}"
+            unlisted: true
+          - address: "0000:03:00.0"
+            set_numvfs: 2
+
+          # Enable 2 VFs and rename them to asd4v1, asd4v2 + Make sure OpenNebula does use them (unlisted <- false).
+          - address: "0000:04:00.*"
+            set_driver: vfio-pci # usual requirement for OpenNebula VMs
+            set_name: "asd4v{0[3]}"
+          - address: "0000:04:00.0"
+            set_numvfs: 2
+      roles:
+        - role: opennebula.deploy.helper.facts
+        - role: opennebula.deploy.helper.pci
+
+    - hosts: node
+      vars:
+        pci_devices:
+          # Enable all available VFs for all existing Mellanox PFs.
+          - vendor: "15b3"
+            device: "1015"
+            class: "0200"
+            set_numvfs: max
+
+          # Rename all existing Mellanox VFs.
+          - vendor: "15b3"
+            device: "1016"
+            class: "0200"
+            set_name: "vf{0[2]}{0[3]}"
+      roles:
+        - role: opennebula.deploy.helper.facts
+        - role: opennebula.deploy.helper.pci
+
+    - hosts: node
+      vars:
+        pci_devices:
+          # Rename and unlist all NICs matching MAC address wildcard.
+          - address: "52:54:00:12:3*:*"
+            set_name: "unlist{0[1]}v{0[3]}"
+            unlisted: true
       roles:
         - role: opennebula.deploy.helper.facts
         - role: opennebula.deploy.helper.pci

--- a/roles/helper/pci/README.md
+++ b/roles/helper/pci/README.md
@@ -11,21 +11,21 @@ N/A
 Role Variables
 --------------
 
-| Name                        | Type  | Default   | Description                                                                         |
-|-----------------------------|-------|-----------|-------------------------------------------------------------------------------------|
-| `pci_devices`               | `list`| `[]`      | PCI devices configuration.                                                          |
-| `pci_devices[].excluded`    | `bool`| `false`   | Do not process matching PCI devices.                                                |
-| `pci_devices[].unguarded`   | `bool`| `false`   | Do not protect matching PCI devices (this may cause primary NIC connectivity loss). |
-| `pci_devices[].unlisted`    | `bool`| `true`    | Do not pass matching PCI devices to OpenNebula.                                     |
-| `pci_devices[].virtual`     | `bool`| `false`   | Do not fail query on missing virtual devices (SR-IOV).                              |
-| `pci_devices[].address`     | `str` | undefined | Glob PCI devices by PCI or MAC address.                                             |
-| `pci_devices[].vendor`      | `str` | `*`       | Glob PCI devices by PCI Vendor (if address is undefined).                           |
-| `pci_devices[].device`      | `str` | `*`       | Glob PCI devices by PCI Device (if address is undefined).                           |
-| `pci_devices[].class`       | `str` | `*`       | Glob PCI devices by PCI Class (if address is undefined).                            |
-| `pci_devices[].set_counter` | `str` | undefined | Reset the "set_counter" internal counter that can be used with set_name ("{3}").    |
-| `pci_devices[].set_driver`  | `str` | `omit`    | Use driverctl to override driver (unless "omit").                                   |
-| `pci_devices[].set_name`    | `str` | `omit`    | Rename device in udev (unless "omit").                                              |
-| `pci_devices[].set_numvfs`  | `str` | `0`       | Enable Virtual Functions for SR-IOV capable devices (integer >= 0 or "max").        |
+| Name                        | Type   | Default   | Description                                                                         |
+|-----------------------------|--------|-----------|-------------------------------------------------------------------------------------|
+| `pci_devices`               | `list` | `[]`      | PCI devices configuration.                                                          |
+| `pci_devices[].excluded`    | `bool` | `false`   | Do not process matching PCI devices.                                                |
+| `pci_devices[].unguarded`   | `bool` | `false`   | Do not protect matching PCI devices (this may cause primary NIC connectivity loss). |
+| `pci_devices[].unlisted`    | `bool` | `true`    | Do not pass matching PCI devices to OpenNebula.                                     |
+| `pci_devices[].virtual`     | `bool` | `false`   | Do not fail query on missing virtual devices (SR-IOV).                              |
+| `pci_devices[].address`     | `str`  | undefined | Glob PCI devices by PCI or MAC address.                                             |
+| `pci_devices[].vendor`      | `str`  | `*`       | Glob PCI devices by PCI Vendor (if address is undefined).                           |
+| `pci_devices[].device`      | `str`  | `*`       | Glob PCI devices by PCI Device (if address is undefined).                           |
+| `pci_devices[].class`       | `str`  | `*`       | Glob PCI devices by PCI Class (if address is undefined).                            |
+| `pci_devices[].set_counter` | `str`  | undefined | Reset the "set_counter" internal counter that can be used with set_name ("{3}").    |
+| `pci_devices[].set_driver`  | `str`  | `omit`    | Use driverctl to override driver (unless "omit").                                   |
+| `pci_devices[].set_name`    | `str`  | `omit`    | Rename device in udev (unless "omit").                                              |
+| `pci_devices[].set_numvfs`  | `str`  | `0`       | Enable Virtual Functions for SR-IOV capable devices (integer >= 0 or "max").        |
 
 Dependencies
 ------------

--- a/roles/helper/pci/README.md
+++ b/roles/helper/pci/README.md
@@ -17,6 +17,7 @@ Role Variables
 | `pci_devices[*].excluded`   | `bool`| `false`   | (check below) | Do not process matching PCI devices.                                                |
 | `pci_devices[*].unguarded`  | `bool`| `false`   | (check below) | Do not protect matching PCI devices (this may cause primary NIC connectivity loss). |
 | `pci_devices[*].unlisted`   | `bool`| `false`   | (check below) | Do not pass matching PCI devices to OpenNebula.                                     |
+| `pci_devices[*].virtual`    | `bool`| `false`   | (check below) | Do not fail query on missing virtual devices (SR-IOV).                              |
 | `pci_devices[*].address`    | `str` | undefined | (check below) | Glob PCI devices by PCI or MAC address.                                             |
 | `pci_devices[*].vendor`     | `str` | `*`       | (check below) | Glob PCI devices by PCI Vendor (if address is undefined).                           |
 | `pci_devices[*].device`     | `str` | `*`       | (check below) | Glob PCI devices by PCI Device (if address is undefined).                           |
@@ -99,12 +100,6 @@ Example Playbook
     - hosts: node
       vars:
         pci_devices:
-          # Rename all existing Mellanox VFs.
-          - vendor: "15b3"
-            device: "*"
-            class: "0200"
-            set_name: "pf{1[1]}{1[2]}{1[3]}vf{2}"
-
           # Enable all available VFs for all existing Mellanox PFs + rename PFs.
           - vendor: "15b3"
             device: "1015"
@@ -112,6 +107,12 @@ Example Playbook
             set_numvfs: max
             set_name: "pf{0[1]}{0[2]}{0[3]}"
 
+          # Rename all existing Mellanox VFs.
+          - vendor: "15b3"
+            device: "1016"
+            class: "0200"
+            virtual: true
+            set_name: "pf{1[1]}{1[2]}{1[3]}vf{2}"
       roles:
         - role: opennebula.deploy.helper.facts
         - role: opennebula.deploy.helper.pci

--- a/roles/helper/pci/README.md
+++ b/roles/helper/pci/README.md
@@ -11,20 +11,21 @@ N/A
 Role Variables
 --------------
 
-| Name                        | Type  | Default   | Example       | Description                                                                         |
-|-----------------------------|-------|-----------|---------------|-------------------------------------------------------------------------------------|
-| `pci_devices`               | `list`| `[]`      | (check below) | PCI devices configuration.                                                          |
-| `pci_devices[*].excluded`   | `bool`| `false`   | (check below) | Do not process matching PCI devices.                                                |
-| `pci_devices[*].unguarded`  | `bool`| `false`   | (check below) | Do not protect matching PCI devices (this may cause primary NIC connectivity loss). |
-| `pci_devices[*].unlisted`   | `bool`| `true`    | (check below) | Do not pass matching PCI devices to OpenNebula.                                     |
-| `pci_devices[*].virtual`    | `bool`| `false`   | (check below) | Do not fail query on missing virtual devices (SR-IOV).                              |
-| `pci_devices[*].address`    | `str` | undefined | (check below) | Glob PCI devices by PCI or MAC address.                                             |
-| `pci_devices[*].vendor`     | `str` | `*`       | (check below) | Glob PCI devices by PCI Vendor (if address is undefined).                           |
-| `pci_devices[*].device`     | `str` | `*`       | (check below) | Glob PCI devices by PCI Device (if address is undefined).                           |
-| `pci_devices[*].class`      | `str` | `*`       | (check below) | Glob PCI devices by PCI Class (if address is undefined).                            |
-| `pci_devices[*].set_driver` | `str` | `omit`    | (check below) | Use driverctl to override driver (unless "omit").                                   |
-| `pci_devices[*].set_name`   | `str` | `omit`    | (check below) | Rename device in udev (unless "omit").                                              |
-| `pci_devices[*].set_numvfs` | `str` | `0`       | (check below) | Enable Virtual Functions for SR-IOV capable devices (integer >= 0 or "max").        |
+| Name                        | Type  | Default   | Description                                                                         |
+|-----------------------------|-------|-----------|-------------------------------------------------------------------------------------|
+| `pci_devices`               | `list`| `[]`      | PCI devices configuration.                                                          |
+| `pci_devices[].excluded`    | `bool`| `false`   | Do not process matching PCI devices.                                                |
+| `pci_devices[].unguarded`   | `bool`| `false`   | Do not protect matching PCI devices (this may cause primary NIC connectivity loss). |
+| `pci_devices[].unlisted`    | `bool`| `true`    | Do not pass matching PCI devices to OpenNebula.                                     |
+| `pci_devices[].virtual`     | `bool`| `false`   | Do not fail query on missing virtual devices (SR-IOV).                              |
+| `pci_devices[].address`     | `str` | undefined | Glob PCI devices by PCI or MAC address.                                             |
+| `pci_devices[].vendor`      | `str` | `*`       | Glob PCI devices by PCI Vendor (if address is undefined).                           |
+| `pci_devices[].device`      | `str` | `*`       | Glob PCI devices by PCI Device (if address is undefined).                           |
+| `pci_devices[].class`       | `str` | `*`       | Glob PCI devices by PCI Class (if address is undefined).                            |
+| `pci_devices[].set_counter` | `str` | undefined | Reset the "set_counter" internal counter that can be used with set_name ("{3}").    |
+| `pci_devices[].set_driver`  | `str` | `omit`    | Use driverctl to override driver (unless "omit").                                   |
+| `pci_devices[].set_name`    | `str` | `omit`    | Rename device in udev (unless "omit").                                              |
+| `pci_devices[].set_numvfs`  | `str` | `0`       | Enable Virtual Functions for SR-IOV capable devices (integer >= 0 or "max").        |
 
 Dependencies
 ------------
@@ -51,7 +52,8 @@ Example Playbook
             #       1[1] -> PCI Bus (SR-IOV PF)
             #       1[2] -> PCI Device (SR-IOV PF)
             #       1[3] -> PCI Function (SR-IOV PF)
-            # NOTE: 2    -> index (SR-IOV VF)
+            # NOTE: 2    -> "virtfn" index (SR-IOV VF)
+            # NOTE: 3    -> index derived from set_counter
             set_name: "pf{1[1]}{1[2]}vf{2}"
 
           # Do not rename "0000:04:00.0" + If it's SR-IOV capable, enable all available VFs.
@@ -99,6 +101,23 @@ Example Playbook
     - hosts: node
       vars:
         pci_devices:
+          # Enable all available VFs of 2 distinct PFs (virtio-net-pci) + rename using single counter.
+          - address: '0000:30:00.*'
+            set_counter: 0
+            set_name: 'vf{3}'
+          - address: '0000:40:00.*'
+            set_name: 'vf{3}'
+          - address: '0000:30:00.0'
+            set_numvfs: max
+          - address: '0000:40:00.0'
+            set_numvfs: max
+      roles:
+        - role: opennebula.deploy.helper.facts
+        - role: opennebula.deploy.helper.pci
+
+    - hosts: node
+      vars:
+        pci_devices:
           # Enable all available VFs for all existing Mellanox PFs + rename PFs.
           - vendor: "15b3"
             device: "1015"
@@ -119,9 +138,31 @@ Example Playbook
     - hosts: node
       vars:
         pci_devices:
+          # Enable all available VFs for all existing Mellanox PFs.
+          - vendor: "15b3"
+            device: "1015"
+            class: "0200"
+            set_numvfs: max
+
+          # Rename all existing Mellanox VFs using custom counter (starting from 1), then pass them to OpenNebula.
+          - vendor: "15b3"
+            device: "1016"
+            class: "0200"
+            virtual: true
+            unlisted: false
+            set_counter: 1
+            set_name: "vf{3}"
+      roles:
+        - role: opennebula.deploy.helper.facts
+        - role: opennebula.deploy.helper.pci
+
+    - hosts: node
+      vars:
+        pci_devices:
           # Rename and unlist all NICs matching MAC address wildcard.
           - address: "52:54:00:12:3*:*"
             set_name: "unlist{0[1]}{0{2}}{0[3]}"
+            unlisted: true
       roles:
         - role: opennebula.deploy.helper.facts
         - role: opennebula.deploy.helper.pci

--- a/roles/helper/pci/README.md
+++ b/roles/helper/pci/README.md
@@ -11,18 +11,19 @@ N/A
 Role Variables
 --------------
 
-| Name                        | Type  | Default   | Example       | Description                                                                  |
-|-----------------------------|-------|-----------|---------------|------------------------------------------------------------------------------|
-| `pci_devices`               | `list`| `[]`      | (check below) | PCI devices configuration.                                                   |
-| `pci_devices[*].excluded`   | `bool`| `false`   | (check below) | Do not process matching PCI devices.                                         |
-| `pci_devices[*].unlisted`   | `bool`| `false`   | (check below) | Do not pass matching PCI devices to OpenNebula.                              |
-| `pci_devices[*].address`    | `str` | undefined | (check below) | Glob PCI devices by PCI or MAC address.                                      |
-| `pci_devices[*].vendor`     | `str` | `*`       | (check below) | Glob PCI devices by PCI Vendor (if address is undefined).                    |
-| `pci_devices[*].device`     | `str` | `*`       | (check below) | Glob PCI devices by PCI Device (if address is undefined).                    |
-| `pci_devices[*].class`      | `str` | `*`       | (check below) | Glob PCI devices by PCI Class (if address is undefined).                     |
-| `pci_devices[*].set_driver` | `str` | `omit`    | (check below) | Use driverctl to override driver (unless "omit").                            |
-| `pci_devices[*].set_name`   | `str` | `omit`    | (check below) | Rename device in udev (unless "omit").                                       |
-| `pci_devices[*].set_numvfs` | `str` | `0`       | (check below) | Enable Virtual Functions for SR-IOV capable devices (integer >= 0 or "max"). |
+| Name                        | Type  | Default   | Example       | Description                                                                         |
+|-----------------------------|-------|-----------|---------------|-------------------------------------------------------------------------------------|
+| `pci_devices`               | `list`| `[]`      | (check below) | PCI devices configuration.                                                          |
+| `pci_devices[*].excluded`   | `bool`| `false`   | (check below) | Do not process matching PCI devices.                                                |
+| `pci_devices[*].unguarded`  | `bool`| `false`   | (check below) | Do not protect matching PCI devices (this may cause primary NIC connectivity loss). |
+| `pci_devices[*].unlisted`   | `bool`| `false`   | (check below) | Do not pass matching PCI devices to OpenNebula.                                     |
+| `pci_devices[*].address`    | `str` | undefined | (check below) | Glob PCI devices by PCI or MAC address.                                             |
+| `pci_devices[*].vendor`     | `str` | `*`       | (check below) | Glob PCI devices by PCI Vendor (if address is undefined).                           |
+| `pci_devices[*].device`     | `str` | `*`       | (check below) | Glob PCI devices by PCI Device (if address is undefined).                           |
+| `pci_devices[*].class`      | `str` | `*`       | (check below) | Glob PCI devices by PCI Class (if address is undefined).                            |
+| `pci_devices[*].set_driver` | `str` | `omit`    | (check below) | Use driverctl to override driver (unless "omit").                                   |
+| `pci_devices[*].set_name`   | `str` | `omit`    | (check below) | Rename device in udev (unless "omit").                                              |
+| `pci_devices[*].set_numvfs` | `str` | `0`       | (check below) | Enable Virtual Functions for SR-IOV capable devices (integer >= 0 or "max").        |
 
 Dependencies
 ------------
@@ -74,6 +75,18 @@ Example Playbook
             set_name: "asd4v{0[3]}"
           - address: "0000:04:00.0"
             set_numvfs: 2
+      roles:
+        - role: opennebula.deploy.helper.facts
+        - role: opennebula.deploy.helper.pci
+
+    - hosts: node
+      vars:
+        pci_devices:
+          # Process primary NIC by disabling its protection (NOTE: in general, this may cause connectivity loss!).
+          - address: "0000:02:00.0"
+            unguarded: true
+            unlisted: true
+            set_name: asd0
       roles:
         - role: opennebula.deploy.helper.facts
         - role: opennebula.deploy.helper.pci

--- a/roles/helper/pci/README.md
+++ b/roles/helper/pci/README.md
@@ -103,14 +103,14 @@ Example Playbook
           - vendor: "15b3"
             device: "*"
             class: "0200"
-            set_name: "pf{1[1]}{1[2]}vf{2}"
+            set_name: "pf{1[1]}{1[2]}{1[3]}vf{2}"
 
           # Enable all available VFs for all existing Mellanox PFs + rename PFs.
           - vendor: "15b3"
             device: "1015"
             class: "0200"
             set_numvfs: max
-            set_name: "pf{0[1]}{0[2]}"
+            set_name: "pf{0[1]}{0[2]}{0[3]}"
 
       roles:
         - role: opennebula.deploy.helper.facts

--- a/roles/helper/pci/README.md
+++ b/roles/helper/pci/README.md
@@ -46,7 +46,12 @@ Example Playbook
             #       0[1] -> PCI Bus
             #       0[2] -> PCI Device
             #       0[3] -> PCI Function
-            set_name: "asd{0[1]}v{0[3]}"
+            # NOTE: 1[0] -> PCI Domain (SR-IOV PF)
+            #       1[1] -> PCI Bus (SR-IOV PF)
+            #       1[2] -> PCI Device (SR-IOV PF)
+            #       1[3] -> PCI Function (SR-IOV PF)
+            # NOTE: 2    -> index (SR-IOV VF)
+            set_name: "pf{1[1]}{1[2]}vf{2}"
 
           # Do not rename "0000:04:00.0" + If it's SR-IOV capable, enable all available VFs.
           - address: "0000:04:00.0"
@@ -62,17 +67,17 @@ Example Playbook
           - address: "0000:02:00.0"
             excluded: true
 
-          # Enable 2 VFs and rename them to asd3v1, asd3v2 + Make sure OpenNebula doesn't use them (unlisted <- true).
+          # Enable 2 VFs and rename them to asd3v0, asd3v1 + Make sure OpenNebula doesn't use them (unlisted <- true).
           - address: "0000:03:00.*"
-            set_name: "asd3v{0[3]}"
+            set_name: "asd3vf{2}"
             unlisted: true
           - address: "0000:03:00.0"
             set_numvfs: 2
 
-          # Enable 2 VFs and rename them to asd4v1, asd4v2 + Make sure OpenNebula does use them (unlisted <- false).
+          # Enable 2 VFs and rename them to asd4v0, asd4v1 + Make sure OpenNebula does use them (unlisted <- false).
           - address: "0000:04:00.*"
             set_driver: vfio-pci # usual requirement for OpenNebula VMs
-            set_name: "asd4v{0[3]}"
+            set_name: "asd4vf{2}"
           - address: "0000:04:00.0"
             set_numvfs: 2
       roles:
@@ -94,17 +99,19 @@ Example Playbook
     - hosts: node
       vars:
         pci_devices:
-          # Enable all available VFs for all existing Mellanox PFs.
+          # Rename all existing Mellanox VFs.
+          - vendor: "15b3"
+            device: "*"
+            class: "0200"
+            set_name: "pf{1[1]}{1[2]}vf{2}"
+
+          # Enable all available VFs for all existing Mellanox PFs + rename PFs.
           - vendor: "15b3"
             device: "1015"
             class: "0200"
             set_numvfs: max
+            set_name: "pf{0[1]}{0[2]}"
 
-          # Rename all existing Mellanox VFs.
-          - vendor: "15b3"
-            device: "1016"
-            class: "0200"
-            set_name: "vf{0[2]}{0[3]}"
       roles:
         - role: opennebula.deploy.helper.facts
         - role: opennebula.deploy.helper.pci
@@ -114,7 +121,7 @@ Example Playbook
         pci_devices:
           # Rename and unlist all NICs matching MAC address wildcard.
           - address: "52:54:00:12:3*:*"
-            set_name: "unlist{0[1]}v{0[3]}"
+            set_name: "unlist{0[1]}{0{2}}{0[3]}"
             unlisted: true
       roles:
         - role: opennebula.deploy.helper.facts

--- a/roles/helper/pci/README.md
+++ b/roles/helper/pci/README.md
@@ -16,7 +16,7 @@ Role Variables
 | `pci_devices`               | `list`| `[]`      | (check below) | PCI devices configuration.                                                          |
 | `pci_devices[*].excluded`   | `bool`| `false`   | (check below) | Do not process matching PCI devices.                                                |
 | `pci_devices[*].unguarded`  | `bool`| `false`   | (check below) | Do not protect matching PCI devices (this may cause primary NIC connectivity loss). |
-| `pci_devices[*].unlisted`   | `bool`| `false`   | (check below) | Do not pass matching PCI devices to OpenNebula.                                     |
+| `pci_devices[*].unlisted`   | `bool`| `true`    | (check below) | Do not pass matching PCI devices to OpenNebula.                                     |
 | `pci_devices[*].virtual`    | `bool`| `false`   | (check below) | Do not fail query on missing virtual devices (SR-IOV).                              |
 | `pci_devices[*].address`    | `str` | undefined | (check below) | Glob PCI devices by PCI or MAC address.                                             |
 | `pci_devices[*].vendor`     | `str` | `*`       | (check below) | Glob PCI devices by PCI Vendor (if address is undefined).                           |
@@ -71,12 +71,12 @@ Example Playbook
           # Enable 2 VFs and rename them to asd3v0, asd3v1 + Make sure OpenNebula doesn't use them (unlisted <- true).
           - address: "0000:03:00.*"
             set_name: "asd3vf{2}"
-            unlisted: true
           - address: "0000:03:00.0"
             set_numvfs: 2
 
           # Enable 2 VFs and rename them to asd4v0, asd4v1 + Make sure OpenNebula does use them (unlisted <- false).
           - address: "0000:04:00.*"
+            unlisted: false
             set_driver: vfio-pci # usual requirement for OpenNebula VMs
             set_name: "asd4vf{2}"
           - address: "0000:04:00.0"
@@ -91,7 +91,6 @@ Example Playbook
           # Process primary NIC by disabling its protection (NOTE: in general, this may cause connectivity loss!).
           - address: "0000:02:00.0"
             unguarded: true
-            unlisted: true
             set_name: asd0
       roles:
         - role: opennebula.deploy.helper.facts
@@ -123,7 +122,6 @@ Example Playbook
           # Rename and unlist all NICs matching MAC address wildcard.
           - address: "52:54:00:12:3*:*"
             set_name: "unlist{0[1]}{0{2}}{0[3]}"
-            unlisted: true
       roles:
         - role: opennebula.deploy.helper.facts
         - role: opennebula.deploy.helper.pci

--- a/roles/helper/pci/defaults/main.yml
+++ b/roles/helper/pci/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-pci_passthrough_enabled: false
 pci_devices: []

--- a/roles/helper/pci/tasks/devices.yml
+++ b/roles/helper/pci/tasks/devices.yml
@@ -25,11 +25,7 @@
               v.device | d('*'),
               v.class | d('*'),
             ) | lower,
-            "key_regex": "^{}:{}:{}$".format(
-              (v.vendor | d('*') == '*') | ternary('[^:]*', v.vendor),
-              (v.device | d('*') == '*') | ternary('[^:]*', v.device),
-              (v.class | d('*') == '*') | ternary('[^:]*', v.class),
-            ) | lower,
+            "key_type": "vdc",
           }))
         -}}
       {%- endfor -%}
@@ -37,12 +33,22 @@
     pci_devices_by_address: >-
       {%- set output = [] -%}
       {%- for v in pci_devices | selectattr('address', 'defined') -%}
-        {{-
-          output.append(v | combine({
-            "key": v.address | lower,
-            "key_regex": "^{}$".format(v.address) | lower,
-          }))
-        -}}
+        {%- if v.address is opennebula.deploy.match_address('*:*:*.*', sep='[:.]') -%}
+          {{-
+            output.append(v | combine({
+              "key": v.address | lower,
+              "key_type": "pci",
+            }))
+          -}}
+        {%- endif -%}
+        {%- if v.address is opennebula.deploy.match_address('*:*:*:*:*:*', sep='[:]') -%}
+          {{-
+            output.append(v | combine({
+              "key": v.address | lower,
+              "key_type": "mac",
+            }))
+          -}}
+        {%- endif -%}
       {%- endfor -%}
       {{- output -}}
 
@@ -52,25 +58,6 @@
 
 - when: lspci_devices | count > 0
   block:
-    - name: Ensure udev rules for vfio
-      ansible.builtin.copy:
-        dest: /etc/udev/rules.d/99-vfio.rules
-        owner: 0
-        group: 0
-        mode: u=rw,go=r
-        content: |
-          SUBSYSTEM=="vfio", GROUP="kvm", MODE="0666"
-      register: copy_udev_vfio
-
-    - name: Refresh udev rules
-      ansible.builtin.shell:
-        cmd: |
-          set -o errexit
-          udevadm control --reload-rules && udevadm trigger
-        executable: /bin/bash
-      changed_when: true
-      when: copy_udev_vfio is changed
-
     - name: Render sriov-enable service unit
       ansible.builtin.copy:
         dest: "{{ item.dest }}"
@@ -140,7 +127,7 @@
         _to_revert: >-
           {%- set output = [] -%}
           {%- for v in lspci_devices -%}
-            {%- if (v.ECAP_SRIOV | bool is true) and (v.set_numvfs == 'max' or v.set_numvfs | int > 0) -%}
+            {%- if (v.Ecap_sriov == 'yes') and (v.Set_numvfs == 'max' or v.Set_numvfs | int > 0) -%}
               {{- output.append(v) -}}
             {%- endif -%}
           {%- endfor -%}
@@ -162,10 +149,10 @@
           set -x -o errexit -o pipefail
           CHANGED=false
           {% for v in _to_enable %}
-          {% if v.set_numvfs == 'max' %}
+          {% if v.Set_numvfs == 'max' %}
             SRIOV_NUMVFS="$(head -n1 '/sys/bus/pci/devices/{{ v.Slot }}/sriov_totalvfs')"
-          {% elif v.set_numvfs | int > 0 %}
-            SRIOV_NUMVFS='{{ v.set_numvfs }}'
+          {% elif v.Set_numvfs | int > 0 %}
+            SRIOV_NUMVFS='{{ v.Set_numvfs }}'
           {% else %}
             unset SRIOV_NUMVFS
           {% endif %}
@@ -203,7 +190,7 @@
         _to_enable: >-
           {%- set output = [] -%}
           {%- for v in lspci_devices -%}
-            {%- if (v.ECAP_SRIOV | bool is true) and (v.set_numvfs == 'max' or v.set_numvfs | int > 0) -%}
+            {%- if (v.Ecap_sriov == 'yes') and (v.Set_numvfs == 'max' or v.Set_numvfs | int > 0) -%}
               {{- output.append(v) -}}
             {%- endif -%}
           {%- endfor -%}
@@ -225,14 +212,14 @@
           set -x -o errexit -o pipefail
           BEFORE="$(driverctl list-overrides | sort)" ||:
           {% for v in _to_override %}
-          if ! grep -E -m1 '^{{ v.Slot }}\s+{{ v.set_driver }}$' <<< "$BEFORE"; then
-          {% if (v.ECAP_SRIOV | bool is true) %}
+          if ! grep -E -m1 '^{{ v.Slot }}\s+{{ v.Set_driver }}$' <<< "$BEFORE"; then
+          {% if v.Ecap_sriov == 'yes' %}
             TO_DISABLE="$(systemctl show --all -P Id 'sriov-enable@{{ v.Slot }}-*.service' | grep -E -v '^\s*$')" ||:
             if [[ -n "$TO_DISABLE" ]] && systemctl is-active --quiet $TO_DISABLE; then
               systemctl disable --now $TO_DISABLE # cleanup spurious sriov-enable@ services
             fi
           {% endif %}
-            driverctl set-override '{{ v.Slot }}' '{{ v.set_driver }}' # force the new driver (vfio-pci by default)
+            driverctl set-override '{{ v.Slot }}' '{{ v.Set_driver }}' # force the new driver (vfio-pci by default)
           fi
           {% endfor %}
           AFTER="$(driverctl list-overrides | sort)" ||:
@@ -247,7 +234,7 @@
         _to_override: >-
           {%- set output = [] -%}
           {%- for v in lspci_devices -%}
-            {%- if (v.set_driver != 'omit') and ((v.ECAP_SRIOV | bool is false) or (v.set_numvfs != 'max' and v.set_numvfs | int == 0)) -%}
+            {%- if (v.Set_driver != 'omit') and ((v.Ecap_sriov == 'no') or (v.Set_numvfs != 'max' and v.Set_numvfs | int == 0)) -%}
               {{- output.append(v) -}}
             {%- endif -%}
           {%- endfor -%}

--- a/roles/helper/pci/tasks/devices.yml
+++ b/roles/helper/pci/tasks/devices.yml
@@ -86,7 +86,7 @@
           cmd: |
             [Unit]
             Description=Enable SR-IOV VFs on %I
-            After=network.target
+            After=network-pre.target
 
             [Service]
             Type=oneshot

--- a/roles/helper/pci/tasks/devices.yml
+++ b/roles/helper/pci/tasks/devices.yml
@@ -13,41 +13,39 @@
   retries: 12
   delay: 5
 
-- name: Parse and split pci_devices
+- name: Parse pci_devices (user input)
   ansible.builtin.set_fact:
-    pci_devices_by_vendor_device_class: >-
+    pci_devices: >-
       {%- set output = [] -%}
-      {%- for v in pci_devices | selectattr('address', 'undefined') -%}
-        {{-
-          output.append(v | combine({
-            "key": "{}:{}:{}".format(
-              v.vendor | d('*'),
-              v.device | d('*'),
-              v.class | d('*'),
-            ) | lower,
-            "key_type": "vdc",
-          }))
-        -}}
-      {%- endfor -%}
-      {{- output -}}
-    pci_devices_by_address: >-
-      {%- set output = [] -%}
-      {%- for v in pci_devices | selectattr('address', 'defined') -%}
-        {%- if v.address is opennebula.deploy.match_address('*:*:*.*', sep='[:.]') -%}
+      {%- for v in pci_devices -%}
+        {%- if v.address is undefined -%}
           {{-
             output.append(v | combine({
-              "key": v.address | lower,
-              "key_type": "pci",
+              "key": "{}:{}:{}".format(
+                v.vendor | d('*'),
+                v.device | d('*'),
+                v.class | d('*'),
+              ) | lower,
+              "key_type": "vdc",
             }))
           -}}
-        {%- endif -%}
-        {%- if v.address is opennebula.deploy.match_address('*:*:*:*:*:*', sep='[:]') -%}
-          {{-
-            output.append(v | combine({
-              "key": v.address | lower,
-              "key_type": "mac",
-            }))
-          -}}
+        {%- else -%}
+          {%- if v.address is opennebula.deploy.match_address('*:*:*.*', sep='[:.]') -%}
+            {{-
+              output.append(v | combine({
+                "key": v.address | lower,
+                "key_type": "pci",
+              }))
+            -}}
+          {%- endif -%}
+          {%- if v.address is opennebula.deploy.match_address('*:*:*:*:*:*', sep='[:]') -%}
+            {{-
+              output.append(v | combine({
+                "key": v.address | lower,
+                "key_type": "mac",
+              }))
+            -}}
+          {%- endif -%}
         {%- endif -%}
       {%- endfor -%}
       {{- output -}}

--- a/roles/helper/pci/tasks/devices.yml
+++ b/roles/helper/pci/tasks/devices.yml
@@ -3,7 +3,7 @@
   ansible.builtin.package:
     name: "{{ _common + _specific[ansible_os_family] }}"
   vars:
-    _common: [bash, coreutils, driverctl, grep, pciutils]
+    _common: [bash, coreutils, driverctl, findutils, grep, pciutils]
     _specific:
       Debian: []
       RedHat: []

--- a/roles/helper/pci/tasks/main.yml
+++ b/roles/helper/pci/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
-- when: pci_passthrough_enabled | bool is true
+- when:
+    - pci_devices is sequence
+    - pci_devices | count > 0
   block:
-    - ansible.builtin.import_tasks:
+    - ansible.builtin.include_tasks:
         file: "{{ role_path }}/tasks/devices.yml"
-      when:
-        - pci_devices is defined
-        - pci_devices is sequence
-        - pci_devices | count > 0
+
+    - ansible.builtin.include_tasks:
+        file: "{{ role_path }}/tasks/udev.yml"

--- a/roles/helper/pci/tasks/query.yml
+++ b/roles/helper/pci/tasks/query.yml
@@ -3,7 +3,8 @@
   ansible.builtin.shell:
     cmd: |
       set -o errexit -o pipefail
-      {% for v in pci_devices_by_vendor_device_class | selectattr('key_type', '==', 'vdc') %}
+      {% for v in pci_devices %}
+      {% if v.key_type == 'vdc' %}
       STDOUT="$(lspci -vmm -nkD -d '{{ v.key }}')"
       if [[ -n "$STDOUT" ]]; then
         echo "$STDOUT"
@@ -26,8 +27,7 @@
         echo -e 'Excluded:\t{{ v.excluded | d(false) | bool | ternary('yes', 'no') }}'
         echo
       done
-      {% endfor %}
-      {% for v in pci_devices_by_address | selectattr('key_type', '==', 'pci') %}
+      {% elif v.key_type == 'pci' %}
       STDOUT="$(lspci -vmm -nkD -s '{{ v.key }}')"
       if [[ -n "$STDOUT" ]]; then
         echo "$STDOUT"
@@ -50,8 +50,7 @@
         echo -e 'Excluded:\t{{ v.excluded | d(false) | bool | ternary('yes', 'no') }}'
         echo
       done
-      {% endfor %}
-      {% for v in pci_devices_by_address | selectattr('key_type', '==', 'mac') %}
+      {% elif v.key_type == 'mac' %}
       udevadm trigger -nv -s net -a 'address={{ v.key }}' | while read -r DEVPATH; do
         IFS='/' read -r _ SYS DEVICES ROOT _ SLOT _ <<< "$DEVPATH"
         if [[ "$SYS" != sys || "$DEVICES" != devices || "$ROOT" != pci* ]]; then
@@ -81,6 +80,7 @@
         echo -e 'Excluded:\t{{ v.excluded | d(false) | bool | ternary('yes', 'no') }}'
         echo
       done
+      {% endif %}
       {% endfor %}
     executable: /bin/bash
   register: shell_lspci

--- a/roles/helper/pci/tasks/query.yml
+++ b/roles/helper/pci/tasks/query.yml
@@ -123,29 +123,33 @@
         {{- output.append(_facts[v].slaves | d([_facts[v].device | d(none)] | select)) -}}
       {%- endfor -%}
       {{- output | flatten -}}
-    # Do also a quick crosscheck with OVS/DPDK config (when available).
+    # Extract info from OVS/DPDK config (when available).
+    _ovs_interfaces: >-
+      {{ (ovs.iface | d({})).keys() | intersect(_facts.interfaces) }}
     _dpdk_pci_addrs: >-
       {{ (ovs.iface | d({})).values() | map(attribute='set', default=[])
                                       | map('selectattr', 'options:dpdk-devargs', 'defined')
                                       | select
                                       | flatten
                                       | map(attribute='options:dpdk-devargs') }}
-    _dpdk_interfaces: >-
-      {{ (ovs.iface | d({})).keys() | intersect(_facts.interfaces) }}
   block:
     - name: Query udev for device info
       ansible.builtin.command:
         cmd: "udevadm info --query=property --property=ID_PATH --value {{ _paths | join(' ') }}"
       vars:
+        # NOTE: OVS interfaces are excluded here, as openvswitch role is allowed to handle primary NICs.
+        #       Please make sure to use 'set_driver: omit' so openvswitch role entirely decides what driver should be used.
         _paths: >-
-          {{ (_interfaces + _dpdk_interfaces) | unique
-                                              | map('regex_replace', '^(.*)$', "-p '/sys/class/net/\g<1>'") }}
+          {{ _interfaces | difference(_ovs_interfaces)
+                         | map('regex_replace', '^(.*)$', "-p '/sys/class/net/\g<1>'") }}
       register: command_udevadm_info
       changed_when: false
 
     - name: Gather forbidden PCI addresses
       ansible.builtin.set_fact:
-        pci_forbidden_addresses: "{{ (_pci_addrs + _dpdk_pci_addrs) | unique }}"
+        # NOTE: DPDK PCI addresses are excluded here, as openvswitch role is allowed to handle primary NICs.
+        #       Please make sure to use 'set_driver: omit' so openvswitch role entirely decides what driver should be used.
+        pci_forbidden_addresses: "{{ _pci_addrs | difference(_dpdk_pci_addrs) }}"
       vars:
         _pci_addrs: >-
           {{ command_udevadm_info.stdout_lines | select
@@ -161,7 +165,6 @@
     fail_msg: >-
       Forbidden PCI addresses {{ _detected }} detected, aborting!
       Please adjust 'pci_devices' to exclude forbidden PCI addresses.
-      You might also want to look for conflicts with OVS/DPDK config.
   vars:
     _detected: >-
       {{ lspci_devices | map(attribute='Slot') | intersect(pci_forbidden_addresses) }}

--- a/roles/helper/pci/tasks/query.yml
+++ b/roles/helper/pci/tasks/query.yml
@@ -3,7 +3,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o errexit -o pipefail
-      {% for v in pci_devices_by_vendor_device_class %}
+      {% for v in pci_devices_by_vendor_device_class | selectattr('key_type', '==', 'vdc') %}
       STDOUT="$(lspci -vmm -nkD -d '{{ v.key }}')"
       if [[ -n "$STDOUT" ]]; then
         echo "$STDOUT"
@@ -15,15 +15,19 @@
       setpci -v -d '{{ v.key }}' STATUS | while IFS=' ' read -r SLOT _; do
         echo -e "Slot:\t$SLOT"
         if setpci -s "$SLOT" ECAP_SRIOV.B 1>/dev/null; then
-          echo -e "ECAP_SRIOV:\tyes"
-          echo
+          echo -e "Ecap_sriov:\tyes"
         else
-          echo -e "ECAP_SRIOV:\tno"
-          echo
+          echo -e "Ecap_sriov:\tno"
         fi
+        echo -e 'Set_driver:\t{{ v.set_driver | d('vfio-pci') }}'
+        echo -e 'Set_name:\t{{ v.set_name | d('omit') }}'
+        echo -e 'Set_numvfs:\t{{ v.set_numvfs | d(0) }}'
+        echo -e 'Unlisted:\t{{ v.unlisted | d(false) | bool | ternary('yes', 'no') }}'
+        echo -e 'Excluded:\t{{ v.excluded | d(false) | bool | ternary('yes', 'no') }}'
+        echo
       done
       {% endfor %}
-      {% for v in pci_devices_by_address %}
+      {% for v in pci_devices_by_address | selectattr('key_type', '==', 'pci') %}
       STDOUT="$(lspci -vmm -nkD -s '{{ v.key }}')"
       if [[ -n "$STDOUT" ]]; then
         echo "$STDOUT"
@@ -32,14 +36,51 @@
         echo "Could not find '{{ v.key }}'" >&2
         exit 1
       fi
-      echo -e "Slot:\t{{ v.key }}"
-      if setpci -s '{{ v.key }}' ECAP_SRIOV.B 1>/dev/null; then
-        echo -e "ECAP_SRIOV:\tyes"
+      setpci -v -s '{{ v.key }}' STATUS | while IFS=' ' read -r SLOT _; do
+        echo -e "Slot:\t$SLOT"
+        if setpci -s "$SLOT" ECAP_SRIOV.B 1>/dev/null; then
+          echo -e "Ecap_sriov:\tyes"
+        else
+          echo -e "Ecap_sriov:\tno"
+        fi
+        echo -e 'Set_driver:\t{{ v.set_driver | d('vfio-pci') }}'
+        echo -e 'Set_name:\t{{ v.set_name | d('omit') }}'
+        echo -e 'Set_numvfs:\t{{ v.set_numvfs | d(0) }}'
+        echo -e 'Unlisted:\t{{ v.unlisted | d(false) | bool | ternary('yes', 'no') }}'
+        echo -e 'Excluded:\t{{ v.excluded | d(false) | bool | ternary('yes', 'no') }}'
         echo
-      else
-        echo -e "ECAP_SRIOV:\tno"
+      done
+      {% endfor %}
+      {% for v in pci_devices_by_address | selectattr('key_type', '==', 'mac') %}
+      udevadm trigger -nv -s net -a 'address={{ v.key }}' | while read -r DEVPATH; do
+        IFS='/' read -r _ SYS DEVICES ROOT _ SLOT _ <<< "$DEVPATH"
+        if [[ "$SYS" != sys || "$DEVICES" != devices || "$ROOT" != pci* ]]; then
+          continue
+        fi
+        STDOUT="$(lspci -vmm -nkD -s "$SLOT")"
+        if [[ -n "$STDOUT" ]]; then
+          echo "$STDOUT"
+          echo
+        else
+          echo "Could not find '$SLOT'" >&2
+          exit 1
+        fi
+        echo -e "Slot:\t$SLOT"
+        if setpci -s "$SLOT" ECAP_SRIOV.B 1>/dev/null; then
+          echo -e "Ecap_sriov:\tyes"
+        else
+          echo -e "Ecap_sriov:\tno"
+        fi
+        if [[ -e "$DEVPATH/address" ]]; then
+          echo -e "Address:\t$(cat $DEVPATH/address)"
+        fi
+        echo -e 'Set_driver:\t{{ v.set_driver | d('vfio-pci') }}'
+        echo -e 'Set_name:\t{{ v.set_name | d('omit') }}'
+        echo -e 'Set_numvfs:\t{{ v.set_numvfs | d(0) }}'
+        echo -e 'Unlisted:\t{{ v.unlisted | d(false) | bool | ternary('yes', 'no') }}'
+        echo -e 'Excluded:\t{{ v.excluded | d(false) | bool | ternary('yes', 'no') }}'
         echo
-      fi
+      done
       {% endfor %}
     executable: /bin/bash
   register: shell_lspci
@@ -48,7 +89,7 @@
 - name: Parse lspci's output
   ansible.builtin.set_fact:
     lspci_devices: >-
-      {{ _lspci_devices_filtered_and_extended }}
+      {{ _lspci_devices | rejectattr('Excluded', '==', 'yes') }}
   vars:
     _lspci_devices: >-
       {%- set output = {} -%}
@@ -56,7 +97,6 @@
         {{- output.update(output | combine({v.Slot: v}, recursive=true)) -}}
       {%- endfor -%}
       {{- output.values() | list -}}
-
     _lspci_devices_raw: >-
       {{ shell_lspci.stdout | split(_sep1)
                             | select('truthy')
@@ -66,83 +106,6 @@
     _sep1: "\n\n"
     _sep2: "\n"
     _sep3: ":\t" # noqa no-tabs
-
-    _by_vendor_device_class_excluded: >-
-        {%- set output = [] -%}
-        {%- for v in pci_devices_by_vendor_device_class -%}
-          {%- if v.excluded | d(false) | bool is true -%}
-            {{- output.append(v) -}}
-          {%- endif -%}
-        {%- endfor -%}
-        {{- output -}}
-
-    _by_address_excluded: >-
-        {%- set output = [] -%}
-        {%- for v in pci_devices_by_address -%}
-          {%- if v.excluded | d(false) | bool is true -%}
-            {{- output.append(v) -}}
-          {%- endif -%}
-        {%- endfor -%}
-        {{- output -}}
-
-    _to_exclude: >-
-      {%- set output = [] -%}
-      {%- for v in _lspci_devices -%}
-        {%- set k = "{}:{}:{}".format(v.Vendor, v.Device, v.Class) -%}
-        {%- for x in _by_vendor_device_class_excluded -%}
-          {%- if k | regex_search(x.key_regex) -%}
-            {{- output.append(v.Slot) -}}
-          {%- endif -%}
-        {%- endfor -%}
-        {%- set k = v.Slot -%}
-        {%- for x in _by_address_excluded -%}
-          {%- if k | regex_search(x.key_regex) -%}
-            {{- output.append(v.Slot) -}}
-          {%- endif -%}
-        {%- endfor -%}
-      {%- endfor -%}
-      {{- output | unique -}}
-
-    _lspci_devices_filtered: >-
-      {%- set output = [] -%}
-      {%- for v in _lspci_devices -%}
-        {%- if _to_exclude is not contains(v.Slot) -%}
-          {{- output.append(v) -}}
-        {%- endif -%}
-      {%- endfor -%}
-      {{- output -}}
-
-    _lspci_devices_filtered_and_extended: >-
-      {%- set output = [] -%}
-      {%- for v in _lspci_devices_filtered -%}
-        {%- set to_append = [] %}
-        {%- for x in pci_devices_by_vendor_device_class -%}
-          {%- set k = "{}:{}:{}".format(v.Vendor, v.Device, v.Class) -%}
-          {%- if k | regex_search(x.key_regex) -%}
-            {{-
-              to_append.append(v | combine({
-                "set_driver": x.set_driver | d('vfio-pci'),
-                "set_numvfs": x.set_numvfs | d(0),
-              }))
-            -}}
-          {%- endif -%}
-        {%- endfor -%}
-        {%- for x in pci_devices_by_address -%}
-          {%- set k = v.Slot -%}
-          {%- if k | regex_search(x.key_regex) -%}
-            {{-
-              to_append.append(v | combine({
-                "set_driver": x.set_driver | d('vfio-pci'),
-                "set_numvfs": x.set_numvfs | d(0),
-              }))
-            -}}
-          {%- endif -%}
-        {%- endfor -%}
-        {%- if to_append | count > 0 -%}
-          {{- output.append(to_append | last) -}}
-        {%- endif -%}
-      {%- endfor -%}
-      {{- output -}}
 
 - when:
     - pci_forbidden_addresses is undefined

--- a/roles/helper/pci/tasks/query.yml
+++ b/roles/helper/pci/tasks/query.yml
@@ -20,7 +20,7 @@
         else
           echo -e "Ecap_sriov:\tno"
         fi
-        echo -e 'Set_driver:\t{{ v.set_driver | d('vfio-pci') }}'
+        echo -e 'Set_driver:\t{{ v.set_driver | d('omit') }}'
         echo -e 'Set_name:\t{{ v.set_name | d('omit') }}'
         echo -e 'Set_numvfs:\t{{ v.set_numvfs | d(0) }}'
         echo -e 'Unlisted:\t{{ v.unlisted | d(false) | bool | ternary('yes', 'no') }}'
@@ -43,7 +43,7 @@
         else
           echo -e "Ecap_sriov:\tno"
         fi
-        echo -e 'Set_driver:\t{{ v.set_driver | d('vfio-pci') }}'
+        echo -e 'Set_driver:\t{{ v.set_driver | d('omit') }}'
         echo -e 'Set_name:\t{{ v.set_name | d('omit') }}'
         echo -e 'Set_numvfs:\t{{ v.set_numvfs | d(0) }}'
         echo -e 'Unlisted:\t{{ v.unlisted | d(false) | bool | ternary('yes', 'no') }}'
@@ -73,7 +73,7 @@
         if [[ -e "$DEVPATH/address" ]]; then
           echo -e "Address:\t$(cat $DEVPATH/address)"
         fi
-        echo -e 'Set_driver:\t{{ v.set_driver | d('vfio-pci') }}'
+        echo -e 'Set_driver:\t{{ v.set_driver | d('omit') }}'
         echo -e 'Set_name:\t{{ v.set_name | d('omit') }}'
         echo -e 'Set_numvfs:\t{{ v.set_numvfs | d(0) }}'
         echo -e 'Unlisted:\t{{ v.unlisted | d(false) | bool | ternary('yes', 'no') }}'

--- a/roles/helper/pci/tasks/query.yml
+++ b/roles/helper/pci/tasks/query.yml
@@ -110,7 +110,7 @@
 - when:
     - pci_forbidden_addresses is undefined
     - _default is defined
-    - _interfaces | count > 0
+    - _paths | count > 0
   vars:
     _facts: >-
       {{ ansible_facts }}
@@ -132,16 +132,15 @@
                                       | select
                                       | flatten
                                       | map(attribute='options:dpdk-devargs') }}
+    # NOTE: OVS interfaces are excluded here, as openvswitch role is allowed to handle primary NICs.
+    #       Please make sure to use 'set_driver: omit' so openvswitch role entirely decides what driver should be used.
+    _paths: >-
+      {{ _interfaces | difference(_ovs_interfaces)
+                     | map('regex_replace', '^(.*)$', "-p '/sys/class/net/\g<1>'") }}
   block:
     - name: Query udev for device info
       ansible.builtin.command:
         cmd: "udevadm info --query=property --property=ID_PATH --value {{ _paths | join(' ') }}"
-      vars:
-        # NOTE: OVS interfaces are excluded here, as openvswitch role is allowed to handle primary NICs.
-        #       Please make sure to use 'set_driver: omit' so openvswitch role entirely decides what driver should be used.
-        _paths: >-
-          {{ _interfaces | difference(_ovs_interfaces)
-                         | map('regex_replace', '^(.*)$', "-p '/sys/class/net/\g<1>'") }}
       register: command_udevadm_info
       changed_when: false
 

--- a/roles/helper/pci/tasks/query.yml
+++ b/roles/helper/pci/tasks/query.yml
@@ -166,4 +166,4 @@
       Please adjust 'pci_devices' to exclude forbidden PCI addresses.
   vars:
     _detected: >-
-      {{ lspci_devices | map(attribute='Slot') | intersect(pci_forbidden_addresses | d([])) }}
+      {{ lspci_devices | map(attribute='Slot') | intersect(pci_forbidden_addresses) }}

--- a/roles/helper/pci/tasks/query.yml
+++ b/roles/helper/pci/tasks/query.yml
@@ -20,7 +20,7 @@
           echo -e 'Set_name:\t{{ v.set_name | d('omit') }}'
           echo -e 'Set_numvfs:\t{{ v.set_numvfs | d(0) }}'
           echo -e 'Virtual:\t{{ v.virtual | d(false) | bool | ternary('yes', 'no') }}'
-          echo -e 'Unlisted:\t{{ v.unlisted | d(false) | bool | ternary('yes', 'no') }}'
+          echo -e 'Unlisted:\t{{ v.unlisted | d(true) | bool | ternary('yes', 'no') }}'
           echo -e 'Unguarded:\t{{ v.unguarded | d(false) | bool | ternary('yes', 'no') }}'
           echo -e 'Excluded:\t{{ v.excluded | d(false) | bool | ternary('yes', 'no') }}'
           echo
@@ -47,7 +47,7 @@
           echo -e 'Set_name:\t{{ v.set_name | d('omit') }}'
           echo -e 'Set_numvfs:\t{{ v.set_numvfs | d(0) }}'
           echo -e 'Virtual:\t{{ v.virtual | d(false) | bool | ternary('yes', 'no') }}'
-          echo -e 'Unlisted:\t{{ v.unlisted | d(false) | bool | ternary('yes', 'no') }}'
+          echo -e 'Unlisted:\t{{ v.unlisted | d(true) | bool | ternary('yes', 'no') }}'
           echo -e 'Unguarded:\t{{ v.unguarded | d(false) | bool | ternary('yes', 'no') }}'
           echo -e 'Excluded:\t{{ v.excluded | d(false) | bool | ternary('yes', 'no') }}'
           echo
@@ -81,7 +81,7 @@
           echo -e 'Set_name:\t{{ v.set_name | d('omit') }}'
           echo -e 'Set_numvfs:\t{{ v.set_numvfs | d(0) }}'
           echo -e 'Virtual:\t{{ v.virtual | d(false) | bool | ternary('yes', 'no') }}'
-          echo -e 'Unlisted:\t{{ v.unlisted | d(false) | bool | ternary('yes', 'no') }}'
+          echo -e 'Unlisted:\t{{ v.unlisted | d(true) | bool | ternary('yes', 'no') }}'
           echo -e 'Unguarded:\t{{ v.unguarded | d(false) | bool | ternary('yes', 'no') }}'
           echo -e 'Excluded:\t{{ v.excluded | d(false) | bool | ternary('yes', 'no') }}'
           echo

--- a/roles/helper/pci/tasks/query.yml
+++ b/roles/helper/pci/tasks/query.yml
@@ -110,7 +110,7 @@
 - when:
     - pci_forbidden_addresses is undefined
     - _default is defined
-    - _paths | count > 0
+    - _interfaces | count > 0
   vars:
     _facts: >-
       {{ ansible_facts }}
@@ -132,15 +132,16 @@
                                       | select
                                       | flatten
                                       | map(attribute='options:dpdk-devargs') }}
-    # NOTE: OVS interfaces are excluded here, as openvswitch role is allowed to handle primary NICs.
-    #       Please make sure to use 'set_driver: omit' so openvswitch role entirely decides what driver should be used.
-    _paths: >-
-      {{ _interfaces | difference(_ovs_interfaces)
-                     | map('regex_replace', '^(.*)$', "-p '/sys/class/net/\g<1>'") }}
   block:
     - name: Query udev for device info
       ansible.builtin.command:
         cmd: "udevadm info --query=property --property=ID_PATH --value {{ _paths | join(' ') }}"
+      vars:
+        # NOTE: OVS interfaces are excluded here, as openvswitch role is allowed to handle primary NICs.
+        #       Please make sure to use 'set_driver: omit' so openvswitch role entirely decides what driver should be used.
+        _paths: >-
+          {{ _interfaces | difference(_ovs_interfaces)
+                         | map('regex_replace', '^(.*)$', "-p '/sys/class/net/\g<1>'") }}
       register: command_udevadm_info
       changed_when: false
 

--- a/roles/helper/pci/tasks/query.yml
+++ b/roles/helper/pci/tasks/query.yml
@@ -24,6 +24,7 @@
         echo -e 'Set_name:\t{{ v.set_name | d('omit') }}'
         echo -e 'Set_numvfs:\t{{ v.set_numvfs | d(0) }}'
         echo -e 'Unlisted:\t{{ v.unlisted | d(false) | bool | ternary('yes', 'no') }}'
+        echo -e 'Unguarded:\t{{ v.unguarded | d(false) | bool | ternary('yes', 'no') }}'
         echo -e 'Excluded:\t{{ v.excluded | d(false) | bool | ternary('yes', 'no') }}'
         echo
       done
@@ -47,6 +48,7 @@
         echo -e 'Set_name:\t{{ v.set_name | d('omit') }}'
         echo -e 'Set_numvfs:\t{{ v.set_numvfs | d(0) }}'
         echo -e 'Unlisted:\t{{ v.unlisted | d(false) | bool | ternary('yes', 'no') }}'
+        echo -e 'Unguarded:\t{{ v.unguarded | d(false) | bool | ternary('yes', 'no') }}'
         echo -e 'Excluded:\t{{ v.excluded | d(false) | bool | ternary('yes', 'no') }}'
         echo
       done
@@ -77,6 +79,7 @@
         echo -e 'Set_name:\t{{ v.set_name | d('omit') }}'
         echo -e 'Set_numvfs:\t{{ v.set_numvfs | d(0) }}'
         echo -e 'Unlisted:\t{{ v.unlisted | d(false) | bool | ternary('yes', 'no') }}'
+        echo -e 'Unguarded:\t{{ v.unguarded | d(false) | bool | ternary('yes', 'no') }}'
         echo -e 'Excluded:\t{{ v.excluded | d(false) | bool | ternary('yes', 'no') }}'
         echo
       done
@@ -123,30 +126,23 @@
         {{- output.append(_facts[v].slaves | d([_facts[v].device | d(none)] | select)) -}}
       {%- endfor -%}
       {{- output | flatten -}}
-    # Do also a quick crosscheck with OVS/DPDK config (when available).
-    _dpdk_pci_addrs: >-
-      {{ (ovs.iface | d({})).values() | map(attribute='set', default=[])
-                                      | map('selectattr', 'options:dpdk-devargs', 'defined')
-                                      | select
-                                      | flatten
-                                      | map(attribute='options:dpdk-devargs') }}
-    _dpdk_interfaces: >-
-      {{ (ovs.iface | d({})).keys() | intersect(_facts.interfaces) }}
   block:
     - name: Query udev for device info
       ansible.builtin.command:
         cmd: "udevadm info --query=property --property=ID_PATH --value {{ _paths | join(' ') }}"
       vars:
         _paths: >-
-          {{ (_interfaces + _dpdk_interfaces) | unique
-                                              | map('regex_replace', '^(.*)$', "-p '/sys/class/net/\g<1>'") }}
+          {{ _interfaces | map('regex_replace', '^(.*)$', "-p '/sys/class/net/\g<1>'") }}
       register: command_udevadm_info
       changed_when: false
 
     - name: Gather forbidden PCI addresses
       ansible.builtin.set_fact:
-        pci_forbidden_addresses: "{{ (_pci_addrs + _dpdk_pci_addrs) | unique }}"
+        pci_forbidden_addresses: "{{ _pci_addrs | difference(_pci_addrs_unguarded) }}"
       vars:
+        _pci_addrs_unguarded: >-
+          {{ lspci_devices | selectattr('Unguarded', '==', 'yes')
+                           | map(attribute='Slot') }}
         _pci_addrs: >-
           {{ command_udevadm_info.stdout_lines | select
                                                | map('regex_replace', '^pci-', '') }}
@@ -164,4 +160,5 @@
       You might also want to look for conflicts with OVS/DPDK config.
   vars:
     _detected: >-
-      {{ lspci_devices | map(attribute='Slot') | intersect(pci_forbidden_addresses) }}
+      {{ lspci_devices | map(attribute='Slot')
+                       | intersect(pci_forbidden_addresses | d([])) }}

--- a/roles/helper/pci/tasks/query.yml
+++ b/roles/helper/pci/tasks/query.yml
@@ -7,6 +7,9 @@
       {% if v.key_type == 'vdc' %}
       STDOUT="$(lspci -vmm -nkD -d '{{ v.key }}')"
       if [[ -n "$STDOUT" ]]; then
+      {% if v.set_counter is defined %}
+        echo -e 'Set_counter:\t{{ v.set_counter }}'
+      {% endif %}
         echo "$STDOUT"
         echo
         setpci -v -d '{{ v.key }}' STATUS | while IFS=' ' read -r SLOT _; do
@@ -34,6 +37,9 @@
       {% elif v.key_type == 'pci' %}
       STDOUT="$(lspci -vmm -nkD -s '{{ v.key }}')"
       if [[ -n "$STDOUT" ]]; then
+      {% if v.set_counter is defined %}
+        echo -e 'Set_counter:\t{{ v.set_counter }}'
+      {% endif %}
         echo "$STDOUT"
         echo
         setpci -v -s '{{ v.key }}' STATUS | while IFS=' ' read -r SLOT _; do
@@ -66,6 +72,9 @@
         fi
         STDOUT="$(lspci -vmm -nkD -s "$SLOT")"
         if [[ -n "$STDOUT" ]]; then
+      {% if v.set_counter is defined %}
+          echo -e 'Set_counter:\t{{ v.set_counter }}'
+      {% endif %}
           echo "$STDOUT"
           echo
           echo -e "Slot:\t$SLOT"

--- a/roles/helper/pci/tasks/query.yml
+++ b/roles/helper/pci/tasks/query.yml
@@ -123,33 +123,29 @@
         {{- output.append(_facts[v].slaves | d([_facts[v].device | d(none)] | select)) -}}
       {%- endfor -%}
       {{- output | flatten -}}
-    # Extract info from OVS/DPDK config (when available).
-    _ovs_interfaces: >-
-      {{ (ovs.iface | d({})).keys() | intersect(_facts.interfaces) }}
+    # Do also a quick crosscheck with OVS/DPDK config (when available).
     _dpdk_pci_addrs: >-
       {{ (ovs.iface | d({})).values() | map(attribute='set', default=[])
                                       | map('selectattr', 'options:dpdk-devargs', 'defined')
                                       | select
                                       | flatten
                                       | map(attribute='options:dpdk-devargs') }}
+    _dpdk_interfaces: >-
+      {{ (ovs.iface | d({})).keys() | intersect(_facts.interfaces) }}
   block:
     - name: Query udev for device info
       ansible.builtin.command:
         cmd: "udevadm info --query=property --property=ID_PATH --value {{ _paths | join(' ') }}"
       vars:
-        # NOTE: OVS interfaces are excluded here, as openvswitch role is allowed to handle primary NICs.
-        #       Please make sure to use 'set_driver: omit' so openvswitch role entirely decides what driver should be used.
         _paths: >-
-          {{ _interfaces | difference(_ovs_interfaces)
-                         | map('regex_replace', '^(.*)$', "-p '/sys/class/net/\g<1>'") }}
+          {{ (_interfaces + _dpdk_interfaces) | unique
+                                              | map('regex_replace', '^(.*)$', "-p '/sys/class/net/\g<1>'") }}
       register: command_udevadm_info
       changed_when: false
 
     - name: Gather forbidden PCI addresses
       ansible.builtin.set_fact:
-        # NOTE: DPDK PCI addresses are excluded here, as openvswitch role is allowed to handle primary NICs.
-        #       Please make sure to use 'set_driver: omit' so openvswitch role entirely decides what driver should be used.
-        pci_forbidden_addresses: "{{ _pci_addrs | difference(_dpdk_pci_addrs) }}"
+        pci_forbidden_addresses: "{{ (_pci_addrs + _dpdk_pci_addrs) | unique }}"
       vars:
         _pci_addrs: >-
           {{ command_udevadm_info.stdout_lines | select
@@ -165,6 +161,7 @@
     fail_msg: >-
       Forbidden PCI addresses {{ _detected }} detected, aborting!
       Please adjust 'pci_devices' to exclude forbidden PCI addresses.
+      You might also want to look for conflicts with OVS/DPDK config.
   vars:
     _detected: >-
       {{ lspci_devices | map(attribute='Slot') | intersect(pci_forbidden_addresses) }}

--- a/roles/helper/pci/tasks/query.yml
+++ b/roles/helper/pci/tasks/query.yml
@@ -9,49 +9,55 @@
       if [[ -n "$STDOUT" ]]; then
         echo "$STDOUT"
         echo
+        setpci -v -d '{{ v.key }}' STATUS | while IFS=' ' read -r SLOT _; do
+          echo -e "Slot:\t$SLOT"
+          if setpci -s "$SLOT" ECAP_SRIOV.B 1>/dev/null; then
+            echo -e "Ecap_sriov:\tyes"
+          else
+            echo -e "Ecap_sriov:\tno"
+          fi
+          echo -e 'Set_driver:\t{{ v.set_driver | d('omit') }}'
+          echo -e 'Set_name:\t{{ v.set_name | d('omit') }}'
+          echo -e 'Set_numvfs:\t{{ v.set_numvfs | d(0) }}'
+          echo -e 'Virtual:\t{{ v.virtual | d(false) | bool | ternary('yes', 'no') }}'
+          echo -e 'Unlisted:\t{{ v.unlisted | d(false) | bool | ternary('yes', 'no') }}'
+          echo -e 'Unguarded:\t{{ v.unguarded | d(false) | bool | ternary('yes', 'no') }}'
+          echo -e 'Excluded:\t{{ v.excluded | d(false) | bool | ternary('yes', 'no') }}'
+          echo
+        done
       else
         echo "Could not find '{{ v.key }}'" >&2
+      {% if v.virtual | d(false) | bool is false %}
         exit 1
+      {% endif %}
       fi
-      setpci -v -d '{{ v.key }}' STATUS | while IFS=' ' read -r SLOT _; do
-        echo -e "Slot:\t$SLOT"
-        if setpci -s "$SLOT" ECAP_SRIOV.B 1>/dev/null; then
-          echo -e "Ecap_sriov:\tyes"
-        else
-          echo -e "Ecap_sriov:\tno"
-        fi
-        echo -e 'Set_driver:\t{{ v.set_driver | d('omit') }}'
-        echo -e 'Set_name:\t{{ v.set_name | d('omit') }}'
-        echo -e 'Set_numvfs:\t{{ v.set_numvfs | d(0) }}'
-        echo -e 'Unlisted:\t{{ v.unlisted | d(false) | bool | ternary('yes', 'no') }}'
-        echo -e 'Unguarded:\t{{ v.unguarded | d(false) | bool | ternary('yes', 'no') }}'
-        echo -e 'Excluded:\t{{ v.excluded | d(false) | bool | ternary('yes', 'no') }}'
-        echo
-      done
       {% elif v.key_type == 'pci' %}
       STDOUT="$(lspci -vmm -nkD -s '{{ v.key }}')"
       if [[ -n "$STDOUT" ]]; then
         echo "$STDOUT"
         echo
+        setpci -v -s '{{ v.key }}' STATUS | while IFS=' ' read -r SLOT _; do
+          echo -e "Slot:\t$SLOT"
+          if setpci -s "$SLOT" ECAP_SRIOV.B 1>/dev/null; then
+            echo -e "Ecap_sriov:\tyes"
+          else
+            echo -e "Ecap_sriov:\tno"
+          fi
+          echo -e 'Set_driver:\t{{ v.set_driver | d('omit') }}'
+          echo -e 'Set_name:\t{{ v.set_name | d('omit') }}'
+          echo -e 'Set_numvfs:\t{{ v.set_numvfs | d(0) }}'
+          echo -e 'Virtual:\t{{ v.virtual | d(false) | bool | ternary('yes', 'no') }}'
+          echo -e 'Unlisted:\t{{ v.unlisted | d(false) | bool | ternary('yes', 'no') }}'
+          echo -e 'Unguarded:\t{{ v.unguarded | d(false) | bool | ternary('yes', 'no') }}'
+          echo -e 'Excluded:\t{{ v.excluded | d(false) | bool | ternary('yes', 'no') }}'
+          echo
+        done
       else
         echo "Could not find '{{ v.key }}'" >&2
+      {% if v.virtual | d(false) | bool is false %}
         exit 1
+      {% endif %}
       fi
-      setpci -v -s '{{ v.key }}' STATUS | while IFS=' ' read -r SLOT _; do
-        echo -e "Slot:\t$SLOT"
-        if setpci -s "$SLOT" ECAP_SRIOV.B 1>/dev/null; then
-          echo -e "Ecap_sriov:\tyes"
-        else
-          echo -e "Ecap_sriov:\tno"
-        fi
-        echo -e 'Set_driver:\t{{ v.set_driver | d('omit') }}'
-        echo -e 'Set_name:\t{{ v.set_name | d('omit') }}'
-        echo -e 'Set_numvfs:\t{{ v.set_numvfs | d(0) }}'
-        echo -e 'Unlisted:\t{{ v.unlisted | d(false) | bool | ternary('yes', 'no') }}'
-        echo -e 'Unguarded:\t{{ v.unguarded | d(false) | bool | ternary('yes', 'no') }}'
-        echo -e 'Excluded:\t{{ v.excluded | d(false) | bool | ternary('yes', 'no') }}'
-        echo
-      done
       {% elif v.key_type == 'mac' %}
       udevadm trigger -nv -s net -a 'address={{ v.key }}' | while read -r DEVPATH; do
         IFS='/' read -r _ SYS DEVICES ROOT _ SLOT _ <<< "$DEVPATH"
@@ -62,26 +68,29 @@
         if [[ -n "$STDOUT" ]]; then
           echo "$STDOUT"
           echo
+          echo -e "Slot:\t$SLOT"
+          if setpci -s "$SLOT" ECAP_SRIOV.B 1>/dev/null; then
+            echo -e "Ecap_sriov:\tyes"
+          else
+            echo -e "Ecap_sriov:\tno"
+          fi
+          if [[ -e "$DEVPATH/address" ]]; then
+            echo -e "Address:\t$(cat $DEVPATH/address)"
+          fi
+          echo -e 'Set_driver:\t{{ v.set_driver | d('omit') }}'
+          echo -e 'Set_name:\t{{ v.set_name | d('omit') }}'
+          echo -e 'Set_numvfs:\t{{ v.set_numvfs | d(0) }}'
+          echo -e 'Virtual:\t{{ v.virtual | d(false) | bool | ternary('yes', 'no') }}'
+          echo -e 'Unlisted:\t{{ v.unlisted | d(false) | bool | ternary('yes', 'no') }}'
+          echo -e 'Unguarded:\t{{ v.unguarded | d(false) | bool | ternary('yes', 'no') }}'
+          echo -e 'Excluded:\t{{ v.excluded | d(false) | bool | ternary('yes', 'no') }}'
+          echo
         else
           echo "Could not find '$SLOT'" >&2
+      {% if v.virtual | d(false) | bool is false %}
           exit 1
+      {% endif %}
         fi
-        echo -e "Slot:\t$SLOT"
-        if setpci -s "$SLOT" ECAP_SRIOV.B 1>/dev/null; then
-          echo -e "Ecap_sriov:\tyes"
-        else
-          echo -e "Ecap_sriov:\tno"
-        fi
-        if [[ -e "$DEVPATH/address" ]]; then
-          echo -e "Address:\t$(cat $DEVPATH/address)"
-        fi
-        echo -e 'Set_driver:\t{{ v.set_driver | d('omit') }}'
-        echo -e 'Set_name:\t{{ v.set_name | d('omit') }}'
-        echo -e 'Set_numvfs:\t{{ v.set_numvfs | d(0) }}'
-        echo -e 'Unlisted:\t{{ v.unlisted | d(false) | bool | ternary('yes', 'no') }}'
-        echo -e 'Unguarded:\t{{ v.unguarded | d(false) | bool | ternary('yes', 'no') }}'
-        echo -e 'Excluded:\t{{ v.excluded | d(false) | bool | ternary('yes', 'no') }}'
-        echo
       done
       {% endif %}
       {% endfor %}

--- a/roles/helper/pci/tasks/query.yml
+++ b/roles/helper/pci/tasks/query.yml
@@ -166,4 +166,4 @@
       Please adjust 'pci_devices' to exclude forbidden PCI addresses.
   vars:
     _detected: >-
-      {{ lspci_devices | map(attribute='Slot') | intersect(pci_forbidden_addresses) }}
+      {{ lspci_devices | map(attribute='Slot') | intersect(pci_forbidden_addresses | d([])) }}

--- a/roles/helper/pci/tasks/udev.yml
+++ b/roles/helper/pci/tasks/udev.yml
@@ -1,0 +1,60 @@
+---
+- when: lspci_devices | count > 0
+  vars:
+    _all: >-
+      {{ lspci_devices | selectattr('Set_name', 'defined')
+                       | rejectattr('Set_name', '==', 'omit')
+                       | selectattr('Class', 'defined')
+                       | selectattr('Driver', 'defined')
+                       | selectattr('Slot', 'defined') }}
+    _net: >-
+      {{ _all | selectattr('Class', 'in', ['0200'])
+              | rejectattr('Driver', 'in', ['vfio-pci']) }}
+    _pci: >-
+      {{ _all | rejectattr('Class', 'in', ['0200'])
+              | rejectattr('Driver', 'in', ['vfio-pci']) }}
+    _vfio: >-
+      {{ _all | selectattr('Driver', 'in', ['vfio-pci'])
+              | selectattr('IOMMUGroup', 'defined') }}
+  block:
+    - name: Render extra udev rules (/etc/udev/rules.d)
+      ansible.builtin.copy:
+        dest: "{{ item.dest }}"
+        content: "{{ item.content }}"
+        owner: 0
+        group: 0
+        mode: u=rw,go=r
+      loop_control: { label: "{{ item.dest }}" }
+      loop:
+        - dest: /etc/udev/rules.d/99-rename.rules
+          content: |
+            # managed by one-deploy
+            # --- NET
+            {% for v in _net %}
+            {% set name = v.Set_name.format(v.Slot | regex_findall('[0-9a-fA-F]+')) %}
+            # {{ v.Slot }} <- {{ name }}
+            SUBSYSTEM=="net", ACTION=="add", ENV{ID_PATH}=="pci-{{ v.Slot }}", NAME="{{ name }}"
+            {% endfor %}
+            # --- PCI
+            {% for v in _pci %}
+            {% set name = v.Set_name.format(v.Slot | regex_findall('[0-9a-fA-F]+')) %}
+            # {{ v.Slot }} <- {{ name }}
+            SUBSYSTEM=="pci", ACTION=="add", ENV{ID_PATH}=="pci-{{ v.Slot }}", SYMLINK+="pci/by-tag/{{ name }}"
+            {% endfor %}
+            # --- VFIO
+            {% for v in _vfio %}
+            {% set name = v.Set_name.format(v.Slot | regex_findall('[0-9a-fA-F]+')) %}
+            # {{ v.Slot }} <- {{ name }}
+            SUBSYSTEM=="vfio", ACTION=="add", KERNEL=="{{ v.IOMMUGroup }}", SYMLINK+="vfio/by-tag/{{ name }}"
+            {% endfor %}
+        - dest: /etc/udev/rules.d/99-mode.rules
+          content: |
+            # managed by one-deploy
+            SUBSYSTEM=="vfio", ACTION=="add", GROUP="kvm", MODE="0666"
+      register: copy_udev_rules
+
+    - name: Refresh udev rules
+      ansible.builtin.shell:
+        cmd: udevadm control --reload-rules && udevadm trigger --action=add
+      changed_when: true
+      when: copy_udev_rules is changed

--- a/roles/helper/pci/tasks/udev.yml
+++ b/roles/helper/pci/tasks/udev.yml
@@ -8,7 +8,7 @@
         {%- if v.Set_counter is defined -%}
           {%- set ns.i = v.Set_counter | int -%}
         {%- endif -%}
-        {%- set ns.output = ns.output + [v | combine({ "Index": ns.i })] -%}
+        {%- set ns.output = ns.output + [v | combine({"Index": ns.i})] -%}
         {%- set ns.i = ns.i + 1 -%}
       {%- endfor -%}
       {{- ns.output -}}
@@ -24,13 +24,8 @@
       {{ _all | selectattr('Class', 'in', ['0200'])
               | rejectattr('Driver', 'in', ['vfio-pci']) }}
 
-    _pci: >-
-      {{ _all | rejectattr('Class', 'in', ['0200'])
-              | rejectattr('Driver', 'in', ['vfio-pci']) }}
-
     _vfio: >-
-      {{ _all | selectattr('Driver', 'in', ['vfio-pci'])
-              | selectattr('IOMMUGroup', 'defined') }}
+      {{ _all | selectattr('IOMMUGroup', 'defined') }}
 
     _vf_to_pf: >-
       {{ shell_vf_to_pf_fn.stdout_lines | d([])
@@ -80,15 +75,6 @@
             # {{ v.Slot }} <- {{ name }}
             SUBSYSTEM=="net", ACTION=="add", ENV{ID_PATH}=="pci-{{ v.Slot }}", NAME="{{ name }}"
             {% endfor %}
-            # --- PCI
-            {% for v in _pci %}
-            {% set name = v.Set_name.format(v.Slot | regex_findall('[0-9a-fA-F]+'),
-                                            _vf_to_pf.get(v.Slot, '') | regex_findall('[0-9a-fA-F]+'),
-                                            _vf_to_fn.get(v.Slot, ''),
-                                            v.Index | d(0)) %}
-            # {{ v.Slot }} <- {{ name }}
-            SUBSYSTEM=="pci", ACTION=="add", ENV{ID_PATH}=="pci-{{ v.Slot }}", SYMLINK+="pci/by-tag/{{ name }}"
-            {% endfor %}
             # --- VFIO
             {% for v in _vfio %}
             {% set name = v.Set_name.format(v.Slot | regex_findall('[0-9a-fA-F]+'),
@@ -96,7 +82,8 @@
                                             _vf_to_fn.get(v.Slot, ''),
                                             v.Index | d(0)) %}
             # {{ v.Slot }} <- {{ name }}
-            SUBSYSTEM=="vfio", ACTION=="add", KERNEL=="{{ v.IOMMUGroup }}", SYMLINK+="vfio/by-tag/{{ name }}"
+            SUBSYSTEM=="vfio", ACTION=="add", SYMLINK+="vfio/by-tag/{{ name }}", \
+            PROGRAM="/usr/bin/test /sys/bus/pci/devices/{{ v.Slot }}/iommu_group -ef /sys/kernel/iommu_groups/%k"
             {% endfor %}
         - dest: /etc/udev/rules.d/99-mode.rules
           content: |

--- a/roles/helper/pci/tasks/udev.yml
+++ b/roles/helper/pci/tasks/udev.yml
@@ -33,23 +33,29 @@
               | selectattr('IOMMUGroup', 'defined') }}
 
     _vf_to_pf: >-
-      {{ shell_vf_to_pf_fn.stdout_lines | map('split', ';')
+      {{ shell_vf_to_pf_fn.stdout_lines | d([])
+                                        | map('split', ';')
                                         | items2dict(key_name=0, value_name=1) }}
 
     _vf_to_fn: >-
-      {{ shell_vf_to_pf_fn.stdout_lines | map('split', ';')
+      {{ shell_vf_to_pf_fn.stdout_lines | d([])
+                                        | map('split', ';')
                                         | items2dict(key_name=0, value_name=2) }}
   block:
     - name: Scan /sys/bus/pci/devices/*/virtfn* (SR-IOV)
       ansible.builtin.shell:
         cmd: |
           set -o errexit -o pipefail
-          {% for v in _lspci_devices | selectattr('Ecap_sriov', '==', 'yes') %}
+          {% for v in _sriov_devices %}
           find -P "/sys/bus/pci/devices/{{ v.Slot }}/" -maxdepth 1 -type l -name 'virtfn*' -printf '%l/%P\n' | while IFS='/' read -r _ VF FN; do
             echo "$VF;{{ v.Slot }};${FN#virtfn}"
           done
           {% endfor %}
         executable: /bin/bash
+      when: _sriov_devices | count > 0
+      vars:
+        _sriov_devices: >-
+          {{ _lspci_devices | selectattr('Ecap_sriov', '==', 'yes') }}
       register: shell_vf_to_pf_fn
       changed_when: false
 

--- a/roles/helper/pci/tasks/udev.yml
+++ b/roles/helper/pci/tasks/udev.yml
@@ -1,12 +1,24 @@
 ---
 - when: lspci_devices | count > 0
   vars:
+    # NOTE: This marks items with indices that can be later used to rename devices.
+    _lspci_devices: >-
+      {%- set ns = namespace(output=[], i=0) -%}
+      {%- for v in lspci_devices -%}
+        {%- if v.Set_counter is defined -%}
+          {%- set ns.i = v.Set_counter | int -%}
+        {%- endif -%}
+        {%- set ns.output = ns.output + [v | combine({ "Index": ns.i })] -%}
+        {%- set ns.i = ns.i + 1 -%}
+      {%- endfor -%}
+      {{- ns.output -}}
+
     _all: >-
-      {{ lspci_devices | selectattr('Set_name', 'defined')
-                       | rejectattr('Set_name', '==', 'omit')
-                       | selectattr('Class', 'defined')
-                       | selectattr('Driver', 'defined')
-                       | selectattr('Slot', 'defined') }}
+      {{ _lspci_devices | selectattr('Set_name', 'defined')
+                        | rejectattr('Set_name', '==', 'omit')
+                        | selectattr('Class', 'defined')
+                        | selectattr('Driver', 'defined')
+                        | selectattr('Slot', 'defined') }}
 
     _net: >-
       {{ _all | selectattr('Class', 'in', ['0200'])
@@ -32,9 +44,9 @@
       ansible.builtin.shell:
         cmd: |
           set -o errexit -o pipefail
-          {% for v in lspci_devices | selectattr('Ecap_sriov', '==', 'yes') %}
+          {% for v in _lspci_devices | selectattr('Ecap_sriov', '==', 'yes') %}
           find -P "/sys/bus/pci/devices/{{ v.Slot }}/" -maxdepth 1 -type l -name 'virtfn*' -printf '%l/%P\n' | while IFS='/' read -r _ VF FN; do
-              echo "$VF;{{ v.Slot }};${FN#virtfn}"
+            echo "$VF;{{ v.Slot }};${FN#virtfn}"
           done
           {% endfor %}
         executable: /bin/bash
@@ -57,7 +69,8 @@
             {% for v in _net %}
             {% set name = v.Set_name.format(v.Slot | regex_findall('[0-9a-fA-F]+'),
                                             _vf_to_pf.get(v.Slot, '') | regex_findall('[0-9a-fA-F]+'),
-                                            _vf_to_fn.get(v.Slot, '')) %}
+                                            _vf_to_fn.get(v.Slot, ''),
+                                            v.Index | d(0)) %}
             # {{ v.Slot }} <- {{ name }}
             SUBSYSTEM=="net", ACTION=="add", ENV{ID_PATH}=="pci-{{ v.Slot }}", NAME="{{ name }}"
             {% endfor %}
@@ -65,7 +78,8 @@
             {% for v in _pci %}
             {% set name = v.Set_name.format(v.Slot | regex_findall('[0-9a-fA-F]+'),
                                             _vf_to_pf.get(v.Slot, '') | regex_findall('[0-9a-fA-F]+'),
-                                            _vf_to_fn.get(v.Slot, '')) %}
+                                            _vf_to_fn.get(v.Slot, ''),
+                                            v.Index | d(0)) %}
             # {{ v.Slot }} <- {{ name }}
             SUBSYSTEM=="pci", ACTION=="add", ENV{ID_PATH}=="pci-{{ v.Slot }}", SYMLINK+="pci/by-tag/{{ name }}"
             {% endfor %}
@@ -73,7 +87,8 @@
             {% for v in _vfio %}
             {% set name = v.Set_name.format(v.Slot | regex_findall('[0-9a-fA-F]+'),
                                             _vf_to_pf.get(v.Slot, '') | regex_findall('[0-9a-fA-F]+'),
-                                            _vf_to_fn.get(v.Slot, '')) %}
+                                            _vf_to_fn.get(v.Slot, ''),
+                                            v.Index | d(0)) %}
             # {{ v.Slot }} <- {{ name }}
             SUBSYSTEM=="vfio", ACTION=="add", KERNEL=="{{ v.IOMMUGroup }}", SYMLINK+="vfio/by-tag/{{ name }}"
             {% endfor %}

--- a/roles/helper/pci/tasks/udev.yml
+++ b/roles/helper/pci/tasks/udev.yml
@@ -7,16 +7,40 @@
                        | selectattr('Class', 'defined')
                        | selectattr('Driver', 'defined')
                        | selectattr('Slot', 'defined') }}
+
     _net: >-
       {{ _all | selectattr('Class', 'in', ['0200'])
               | rejectattr('Driver', 'in', ['vfio-pci']) }}
+
     _pci: >-
       {{ _all | rejectattr('Class', 'in', ['0200'])
               | rejectattr('Driver', 'in', ['vfio-pci']) }}
+
     _vfio: >-
       {{ _all | selectattr('Driver', 'in', ['vfio-pci'])
               | selectattr('IOMMUGroup', 'defined') }}
+
+    _vf_to_pf: >-
+      {{ shell_vf_to_pf_fn.stdout_lines | map('split', ';')
+                                        | items2dict(key_name=0, value_name=1) }}
+
+    _vf_to_fn: >-
+      {{ shell_vf_to_pf_fn.stdout_lines | map('split', ';')
+                                        | items2dict(key_name=0, value_name=2) }}
   block:
+    - name: Scan /sys/bus/pci/devices/*/virtfn* (SR-IOV)
+      ansible.builtin.shell:
+        cmd: |
+          set -o errexit -o pipefail
+          {% for v in lspci_devices | selectattr('Ecap_sriov', '==', 'yes') %}
+          find -P "/sys/bus/pci/devices/{{ v.Slot }}/" -maxdepth 1 -type l -name 'virtfn*' -printf '%l/%P\n' | while IFS='/' read -r _ VF FN; do
+              echo "$VF;{{ v.Slot }};${FN#virtfn}"
+          done
+          {% endfor %}
+        executable: /bin/bash
+      register: shell_vf_to_pf_fn
+      changed_when: false
+
     - name: Render extra udev rules (/etc/udev/rules.d)
       ansible.builtin.copy:
         dest: "{{ item.dest }}"
@@ -31,19 +55,25 @@
             # managed by one-deploy
             # --- NET
             {% for v in _net %}
-            {% set name = v.Set_name.format(v.Slot | regex_findall('[0-9a-fA-F]+')) %}
+            {% set name = v.Set_name.format(v.Slot | regex_findall('[0-9a-fA-F]+'),
+                                            _vf_to_pf.get(v.Slot, '') | regex_findall('[0-9a-fA-F]+'),
+                                            _vf_to_fn.get(v.Slot, '')) %}
             # {{ v.Slot }} <- {{ name }}
             SUBSYSTEM=="net", ACTION=="add", ENV{ID_PATH}=="pci-{{ v.Slot }}", NAME="{{ name }}"
             {% endfor %}
             # --- PCI
             {% for v in _pci %}
-            {% set name = v.Set_name.format(v.Slot | regex_findall('[0-9a-fA-F]+')) %}
+            {% set name = v.Set_name.format(v.Slot | regex_findall('[0-9a-fA-F]+'),
+                                            _vf_to_pf.get(v.Slot, '') | regex_findall('[0-9a-fA-F]+'),
+                                            _vf_to_fn.get(v.Slot, '')) %}
             # {{ v.Slot }} <- {{ name }}
             SUBSYSTEM=="pci", ACTION=="add", ENV{ID_PATH}=="pci-{{ v.Slot }}", SYMLINK+="pci/by-tag/{{ name }}"
             {% endfor %}
             # --- VFIO
             {% for v in _vfio %}
-            {% set name = v.Set_name.format(v.Slot | regex_findall('[0-9a-fA-F]+')) %}
+            {% set name = v.Set_name.format(v.Slot | regex_findall('[0-9a-fA-F]+'),
+                                            _vf_to_pf.get(v.Slot, '') | regex_findall('[0-9a-fA-F]+'),
+                                            _vf_to_fn.get(v.Slot, '')) %}
             # {{ v.Slot }} <- {{ name }}
             SUBSYSTEM=="vfio", ACTION=="add", KERNEL=="{{ v.IOMMUGroup }}", SYMLINK+="vfio/by-tag/{{ name }}"
             {% endfor %}

--- a/roles/helper/pci/tasks/udev.yml
+++ b/roles/helper/pci/tasks/udev.yml
@@ -13,6 +13,9 @@
       {%- endfor -%}
       {{- ns.output -}}
 
+    _sriov_devices: >-
+      {{ _lspci_devices | selectattr('Ecap_sriov', '==', 'yes') }}
+
     _all: >-
       {{ _lspci_devices | selectattr('Set_name', 'defined')
                         | rejectattr('Set_name', '==', 'omit')
@@ -47,12 +50,9 @@
           done
           {% endfor %}
         executable: /bin/bash
-      when: _sriov_devices | count > 0
-      vars:
-        _sriov_devices: >-
-          {{ _lspci_devices | selectattr('Ecap_sriov', '==', 'yes') }}
       register: shell_vf_to_pf_fn
       changed_when: false
+      when: _sriov_devices | count > 0
 
     - name: Render extra udev rules (/etc/udev/rules.d)
       ansible.builtin.copy:

--- a/roles/openvswitch/README.md
+++ b/roles/openvswitch/README.md
@@ -48,6 +48,13 @@ Example Playbook
                 - codeready-builder-for-rhel-9-x86_64-rpms
                 - rhel-9-for-x86_64-highavailability-rpms
                 - fast-datapath-for-rhel-9-x86_64-rpms
+        pci_devices:
+          - address: '0000:04:00.0'
+            set_name: asd123
+            unlisted: true
+          - address: '52:54:00:12:34:56'
+            set_name: asd321
+            unlisted: true
         ovs:
           set:
             - other_config:dpdk-init: 'true'
@@ -77,7 +84,9 @@ Example Playbook
                 - mtu_request: 9000
                 - options:dpdk-devargs: '0000:03:00.0'
               driver: omit # skip forcing the driver
-            eth3: {} # non-DPDK device
+            asd123: {} # non-DPDK device (renamed)
+            asd321: {} # non-DPDK device (renamed)
+            eth4: {} # non-DPDK device
           bond:
             bond0:
               ifaces: [dpdk-p1, dpdk-p2]
@@ -94,10 +103,11 @@ Example Playbook
               gw: "{{ ansible_default_ipv4.gateway }}"
               dns: ["{{ ansible_default_ipv4.gateway }}"]
             ovsbr1: # non-DPDK bridge
-              ports: [eth3]
+              ports: [asd123, asd321, eth4]
       roles:
         - role: opennebula.deploy.helper.facts
         - role: opennebula.deploy.helper.kernel
+        - role: opennebula.deploy.helper.pci
         - role: opennebula.deploy.repository
         - role: opennebula.deploy.openvswitch
 

--- a/roles/openvswitch/tasks/main.yml
+++ b/roles/openvswitch/tasks/main.yml
@@ -116,15 +116,18 @@
         that: _dpdk_pci_addrs_raw == _dpdk_pci_addrs_items # no invalid, no duplicated
         fail_msg: Please remove invalid / duplicated DPDK PCI addresses from OVS config.
 
-    - name: Assert DPDK PCI devices are not already claimed by PCI/SR-IOV management
+    - name: Assert DPDK PCI device drivers are not already claimed by PCI/SR-IOV management
       ansible.builtin.assert:
         that: _intersection | count == 0
-        fail_msg: DPDK vs PCI/SR-IOV conflict detected. Please ensure {{ _intersection }} are not being claimed by both implementations.
+        fail_msg: >-
+          DPDK vs PCI/SR-IOV conflict detected.
+          Please ensure drivers of {{ _intersection }} are not managed by helper/pci role already.
       vars:
         _intersection: >-
           {{ _dpdk_pci_addrs.keys() | intersect(_slots) }}
         _slots: >-
           {{ lspci_devices | selectattr('Slot', 'defined')
+                           | rejectattr('Set_driver', 'in', ['omit'])
                            | map(attribute='Slot') }}
       when:
         # NOTE: The 'lspci_devices' fact is produced by the helper/pci role.

--- a/roles/openvswitch/tasks/main.yml
+++ b/roles/openvswitch/tasks/main.yml
@@ -248,24 +248,27 @@
                    | flatten
                    | selectattr('key', 'in', ['addrs', 'gw', 'dns']) }}
 
-    - name: Ensure udev rules for vfio
-      ansible.builtin.copy:
-        dest: /etc/udev/rules.d/99-vfio.rules
-        owner: 0
-        group: 0
-        mode: u=rw,go=r
-        content: |
-          SUBSYSTEM=="vfio", GROUP="kvm", MODE="0666"
-      register: copy_udev_vfio
+    - block:
+        - name: Render extra udev rules (/etc/udev/rules.d)
+          ansible.builtin.copy:
+            dest: "{{ item.dest }}"
+            content: "{{ item.content }}"
+            owner: 0
+            group: 0
+            mode: u=rw,go=r
+          loop_control: { label: "{{ item.dest }}" }
+          loop:
+            - dest: /etc/udev/rules.d/99-mode.rules
+              content: |
+                # managed by one-deploy
+                SUBSYSTEM=="vfio", ACTION=="add", GROUP="kvm", MODE="0666"
+          register: copy_udev_rules
 
-    - name: Refresh udev rules
-      ansible.builtin.shell:
-        cmd: |
-          set -o errexit
-          udevadm control --reload-rules && udevadm trigger
-        executable: /bin/bash
-      changed_when: true
-      when: copy_udev_vfio is changed
+        - name: Refresh udev rules
+          ansible.builtin.shell:
+            cmd: udevadm control --reload-rules && udevadm trigger --action=add --subsystem-match=vfio
+          changed_when: true
+          when: copy_udev_rules is changed
 
     - name: Install OVS packages
       ansible.builtin.package:

--- a/roles/pci/frontend/README.md
+++ b/roles/pci/frontend/README.md
@@ -11,15 +11,14 @@ N/A
 Role Variables
 --------------
 
-| Name                             | Type   | Default | Example | Description                              |
-|----------------------------------|--------|---------|---------|------------------------------------------|
-| `pci_passthrough_enabled`        | `bool` | `false` |         | Enable/Disable PCI passthrough.          |
-| `pci_passthrough_default_filter` | `bool` | `*:*`   |         | Default (global) PCI passthrough filter. |
+| Name                 | Type   | Default | Example | Description                              |
+|----------------------|--------|---------|---------|------------------------------------------|
+| `pci_default_filter` | `bool` | `*:*`   |         | Default (global) PCI passthrough filter. |
 
 Dependencies
 ------------
 
-- opennebula.deploy.opennebula.leader
+N/A
 
 Example Playbook
 ----------------

--- a/roles/pci/frontend/defaults/main.yml
+++ b/roles/pci/frontend/defaults/main.yml
@@ -1,6 +1,2 @@
 ---
-pci_passthrough_enabled: >-
-  {{ (groups[node_group | d('node')] | map('extract', hostvars)
-                                     | map(attribute='pci_passthrough_enabled', default=false)
-                                     | map('bool')) is any }}
-pci_passthrough_default_filter: "*:*" # NOTE: OpenNebula's default is "0:0"
+pci_default_filter: "*:*" # NOTE: OpenNebula's default is "0:0"

--- a/roles/pci/frontend/tasks/main.yml
+++ b/roles/pci/frontend/tasks/main.yml
@@ -1,12 +1,21 @@
 ---
-- name: Apply global PCI filter
-  opennebula.deploy.cfgtool:
-    dest: /var/lib/one/remotes/etc/im/kvm-probes.d/pci.conf
-    parser: Yaml
-    actions:
-      - put:
-          path: [":filter"]
-          value: "{{ pci_passthrough_default_filter }}"
-  notify:
-    - Sync Remotes
-  when: pci_passthrough_enabled | bool is true
+- when: _enabled is true
+  vars:
+    _enabled: >-
+      {{ _hosts | map('extract', hostvars)
+                | map(attribute='pci_devices', default=[])
+                | select
+                | count > 0 }}
+    _hosts: >-
+      {{ groups[node_group | d('node')] }}
+  block:
+    - name: Apply global PCI filter
+      opennebula.deploy.cfgtool:
+        dest: /var/lib/one/remotes/etc/im/kvm-probes.d/pci.conf
+        parser: Yaml
+        actions:
+          - put:
+              path: [":filter"]
+              value: "{{ pci_default_filter }}"
+      notify:
+        - Sync Remotes

--- a/roles/pci/node/README.md
+++ b/roles/pci/node/README.md
@@ -11,10 +11,9 @@ N/A
 Role Variables
 --------------
 
-| Name                      | Type   | Default | Example       | Description                     |
-|---------------------------|--------|---------|---------------|---------------------------------|
-| `pci_passthrough_enabled` | `bool` | `false` |               | Enable/Disable PCI passthrough. |
-| `pci_devices`             | `list` | `[]`    | (check below) | PCI devices configuration.      |
+| Name          | Type   | Default | Example       | Description                     |
+|---------------|--------|---------|---------------|---------------------------------|
+| `pci_devices` | `list` | `[]`    | (check below) | PCI devices configuration.      |
 
 Dependencies
 ------------
@@ -26,10 +25,12 @@ Example Playbook
 
     - hosts: node
       vars:
-        pci_passthrough_enabled: true
         pci_devices:
           - address: "0000:02:00.0"
             excluded: true
+          - address: "0000:03:00.*"
+            unlisted: true
+            set_name: "asd{0[3]}"
           - vendor: "1af4"
             device: "*"
             class: "0200"

--- a/roles/pci/node/README.md
+++ b/roles/pci/node/README.md
@@ -29,11 +29,11 @@ Example Playbook
           - address: "0000:02:00.0"
             excluded: true
           - address: "0000:03:00.*"
-            unlisted: true
             set_name: "asd{0[3]}"
           - vendor: "1af4"
             device: "*"
             class: "0200"
+            unlisted: false
             set_driver: omit # NOTE: 'vfio-pci' is the default, 'omit' skips override altogether
             set_numvfs: max
       roles:

--- a/roles/pci/node/defaults/main.yml
+++ b/roles/pci/node/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-pci_passthrough_enabled: false
 pci_devices: []

--- a/roles/pci/node/tasks/filters.yml
+++ b/roles/pci/node/tasks/filters.yml
@@ -44,8 +44,8 @@
         _after:
           PCI_SHORT_ADDRESS: >-
             {%- set output = [] -%}
-            {%- for v in lspci_devices -%}
-              {%- if (v.ECAP_SRIOV | bool is false) or (v.set_numvfs != 'max' and v.set_numvfs | int == 0) -%}
+            {%- for v in lspci_devices | rejectattr('Unlisted', '==', 'yes') -%}
+              {%- if (v.Ecap_sriov == 'no') or (v.Set_numvfs != 'max' and v.Set_numvfs | int == 0) -%}
                 {{- output.append(v.Slot | regex_replace('^[^:]{4}:(.+)$', '\g<1>')) -}}
               {%- endif -%}
             {%- endfor -%}

--- a/roles/pci/node/tasks/main.yml
+++ b/roles/pci/node/tasks/main.yml
@@ -1,14 +1,20 @@
 ---
-- when: pci_passthrough_enabled | bool is true
+- when: _enabled is true
+  vars:
+    _enabled: >-
+      {{ _hosts | map('extract', hostvars)
+                | map(attribute='pci_devices', default=[])
+                | select
+                | count > 0 }}
+    _hosts: >-
+      {{ groups[node_group | d('node')] }}
   block:
     - ansible.builtin.include_role:
         name: opennebula.deploy.helper.pci
-      when:
-        - lspci_devices is undefined
+      when: lspci_devices is undefined
 
     - ansible.builtin.import_tasks:
         file: "{{ role_path }}/tasks/filters.yml"
       when:
         - lspci_devices is defined
-        - lspci_devices is sequence
         - lspci_devices | count > 0

--- a/roles/precheck/post_reboot/tasks/pci.yml
+++ b/roles/precheck/post_reboot/tasks/pci.yml
@@ -1,7 +1,21 @@
 ---
+- name: Ensure user renames / removes obsolete variables
+  ansible.builtin.assert:
+    that:
+      - pci_passthrough_enabled is undefined
+      - pci_passthrough_default_filter is undefined
+    fail_msg: |
+      Detected obsolete pci_passthrough_* variables.
+      Please remove 'pci_passthrough_enabled' as it no longer has any effect.
+      Please rename 'pci_passthrough_default_filter' to 'pci_default_filter'.
+
 - name: Run PCI passthrough pre-flight checks
-  when: pci_passthrough_enabled | d(false) | bool
+  when:
+    - _pci_devices is sequence
+    - _pci_devices | count > 0
   vars:
+    _pci_devices: >-
+      {{ pci_devices | d([]) }}
     _virtualization_flag: >-
       {{ 'vmx' if 'GenuineIntel' in ansible_facts.processor else
          'svm' if 'AuthenticAMD' in ansible_facts.processor else '' }}

--- a/roles/precheck/pre_reboot/tasks/features.yml
+++ b/roles/precheck/pre_reboot/tasks/features.yml
@@ -94,8 +94,6 @@
 - name: Check if PCI / SR-IOV management is supported for the current distro
   ansible.builtin.assert:
     that:
-      (pci_passthrough_enabled | d(false) | bool is false)
-      or
       (pci_devices | d([]) | count == 0)
       or
       (not (ansible_distribution == 'SLES' and ansible_distribution_major_version == '15'))


### PR DESCRIPTION
- Normalize lspci_devices's structure
- Add 'unlisted' option for hiding PCI devices from OpenNebula
- Add 'set_name' option for naming PCI devices
- Add 'match_address' test plugin to handle wildcards in PCI/MAC addresses
- Add ability to match NICs by their MAC address
- Add udev rules for net/pci/vfio device renaming/symlinking (set_name)
- Rename 99-vfio.rules to 99-mode.rules in both helper/pci and openvswitch roles
- Remove 'pci_passthrough_enabled'
- Rename 'pci_passthrough_default_filter' to 'pci_default_filter'
- Update precheck role
- Update README.md files