### PR TITLE
F #218: Add UDEV rules to auto-unmanage net subsystem devices

### DIFF
--- a/roles/helper/pci/tasks/udev.yml
+++ b/roles/helper/pci/tasks/udev.yml
@@ -140,11 +140,14 @@
             SUBSYSTEM=="net", ACTION=="add|move", ENV{ID_PATH}=="pci-{{ v.Slot }}", \
             ENV{NM_UNMANAGED}="1", ENV{FORCE_NM_UNMANAGED}="1"
             SUBSYSTEM=="net", ENV{ID_PATH}=="pci-{{ v.Slot }}", ENV{FORCE_NM_UNMANAGED}=="1", TEST=="/usr/bin/nmcli", \
-            RUN+="/usr/bin/systemd-run --no-block --property=ConditionPathExists=/sys%E{DEVPATH} /usr/bin/nmcli device set %E{ID_NET_NAME} managed no"
+            RUN+="/usr/bin/systemd-run --no-block --property=ConditionPathExists=/sys%E{DEVPATH} \
+                  /usr/bin/nmcli device set %E{ID_NET_NAME} managed no"
             SUBSYSTEM=="net", ENV{ID_PATH}=="pci-{{ v.Slot }}", ENV{FORCE_NM_UNMANAGED}=="1", TEST=="/usr/sbin/netplan", \
-            RUN+="/usr/bin/systemd-run --no-block --property=ConditionPathExists=/sys%E{DEVPATH} /usr/sbin/netplan set network.ethernets.%E{ID_NET_NAME_PATH}=null"
+            RUN+="/usr/bin/systemd-run --no-block --property=ConditionPathExists=/sys%E{DEVPATH} \
+                  /usr/sbin/netplan set network.ethernets.%E{ID_NET_NAME_PATH}=null"
             SUBSYSTEM=="net", ACTION=="add|move", ENV{ID_PATH}=="pci-{{ v.Slot }}", TEST=="/usr/sbin/ip", \
-            RUN+="/usr/bin/systemd-run --no-block --property=ConditionPathExists=/sys%E{DEVPATH} /usr/sbin/ip link set dev %E{INTERFACE} up"
+            RUN+="/usr/bin/systemd-run --no-block --property=ConditionPathExists=/sys%E{DEVPATH} \
+                  /usr/sbin/ip link set dev %E{INTERFACE} up"
             {% endfor %}
       register: copy_udev_rules
 

--- a/roles/helper/pci/tasks/udev.yml
+++ b/roles/helper/pci/tasks/udev.yml
@@ -17,18 +17,24 @@
       {{ _lspci_devices | selectattr('Ecap_sriov', '==', 'yes') }}
 
     _all: >-
-      {{ _lspci_devices | selectattr('Set_name', 'defined')
-                        | rejectattr('Set_name', '==', 'omit')
-                        | selectattr('Class', 'defined')
+      {{ _lspci_devices | selectattr('Class', 'defined')
                         | selectattr('Driver', 'defined')
                         | selectattr('Slot', 'defined') }}
 
-    _net: >-
+    _to_unmanage: >-
       {{ _all | selectattr('Class', 'in', ['0200'])
               | rejectattr('Driver', 'in', ['vfio-pci']) }}
 
-    _vfio: >-
-      {{ _all | selectattr('IOMMUGroup', 'defined') }}
+    _to_rename: >-
+      {{ _all | selectattr('Set_name', 'defined')
+              | rejectattr('Set_name', '==', 'omit') }}
+
+    _to_rename_net: >-
+      {{ _to_rename | selectattr('Class', 'in', ['0200'])
+                    | rejectattr('Driver', 'in', ['vfio-pci']) }}
+
+    _to_rename_vfio: >-
+      {{ _to_rename | selectattr('IOMMUGroup', 'defined') }}
 
     _vf_to_pf: >-
       {{ shell_pf_vf_fn.stdout_lines | d([])
@@ -43,7 +49,7 @@
     _names: >-
       {%- set output = {} -%}
       {# Resolve basic 0-3 args. #}
-      {%- for v in _all -%}
+      {%- for v in _to_rename -%}
         {{-
           output.update({
             v.Slot: [
@@ -56,7 +62,7 @@
         -}}
       {%- endfor -%}
       {# Add 4th arg (PF's name). #}
-      {%- for v in _all | selectattr('Slot', 'in', _vf_to_pf) -%}
+      {%- for v in _to_rename | selectattr('Slot', 'in', _vf_to_pf) -%}
         {%- set p = _lspci_devices | selectattr('Slot', '==', _vf_to_pf[v.Slot]) | first -%}
         {%- if p.Set_name != 'omit' -%}
           {{-
@@ -67,7 +73,7 @@
         {%- endif -%}
       {%- endfor -%}
       {# Construct all names from templates and args. #}
-      {%- for v in _all -%}
+      {%- for v in _to_rename -%}
         {{-
           output.update({
             v.Slot: v.Set_name.format(*output[v.Slot]),
@@ -101,24 +107,45 @@
         mode: u=rw,go=r
       loop_control: { label: "{{ item.dest }}" }
       loop:
-        - dest: /etc/udev/rules.d/99-rename.rules
-          content: |
-            # managed by one-deploy
-            # --- NET
-            {% for v in _net %}
-            # {{ v.Slot }} <- {{ _names[v.Slot] }}
-            SUBSYSTEM=="net", ACTION=="add", ENV{ID_PATH}=="pci-{{ v.Slot }}", NAME="{{ _names[v.Slot] }}"
-            {% endfor %}
-            # --- VFIO
-            {% for v in _vfio %}
-            # {{ v.Slot }} <- {{ _names[v.Slot] }}
-            SUBSYSTEM=="vfio", ACTION=="add", SYMLINK+="vfio/by-tag/{{ _names[v.Slot] }}", \
-            PROGRAM="/usr/bin/test /sys/bus/pci/devices/{{ v.Slot }}/iommu_group -ef /sys/kernel/iommu_groups/%k"
-            {% endfor %}
         - dest: /etc/udev/rules.d/99-mode.rules
           content: |
             # managed by one-deploy
             SUBSYSTEM=="vfio", ACTION=="add", GROUP="kvm", MODE="0666"
+        - dest: /etc/udev/rules.d/99-rename.rules
+          content: |
+            # managed by one-deploy
+            # --- NET
+            {% for v in _to_rename_net %}
+            # {{ v.Slot }} <- {{ _names[v.Slot] }}
+            SUBSYSTEM=="net", ACTION=="add", ENV{ID_PATH}=="pci-{{ v.Slot }}", NAME="{{ _names[v.Slot] }}"
+            {% endfor %}
+            # --- VFIO
+            {% for v in _to_rename_vfio %}
+            # {{ v.Slot }} <- {{ _names[v.Slot] }}
+            SUBSYSTEM=="vfio", ACTION=="add", SYMLINK+="vfio/by-tag/{{ _names[v.Slot] }}", \
+            PROGRAM="/usr/bin/test /sys/bus/pci/devices/{{ v.Slot }}/iommu_group -ef /sys/kernel/iommu_groups/%k"
+            {% endfor %}
+        # NOTE: NM_UNMANAGED does not seem to be sufficient (unless you reboot) as NM ignores settings in UDEV in case
+        #       the device is already managed.
+        #       FORCE_NM_UNMANAGED that is non-standard variable, used here as NM_UNMANAGED can be modifed by
+        #       something else.
+        #       "/usr/bin/systemd-run --no-block" is used here to never block UDEV + existence of the device can be verified
+        #       without spawning extra shell.
+        - dest: /etc/udev/rules.d/99-unmanage.rules
+          content: |
+            # managed by one-deploy
+            # --- NET
+            {% for v in _to_unmanage %}
+            # {{ v.Slot }}
+            SUBSYSTEM=="net", ACTION=="add|move", ENV{ID_PATH}=="pci-{{ v.Slot }}", \
+            ENV{NM_UNMANAGED}="1", ENV{FORCE_NM_UNMANAGED}="1"
+            SUBSYSTEM=="net", ENV{ID_PATH}=="pci-{{ v.Slot }}", ENV{FORCE_NM_UNMANAGED}=="1", TEST=="/usr/bin/nmcli", \
+            RUN+="/usr/bin/systemd-run --no-block --property=ConditionPathExists=/sys%E{DEVPATH} /usr/bin/nmcli device set %E{ID_NET_NAME} managed no"
+            SUBSYSTEM=="net", ENV{ID_PATH}=="pci-{{ v.Slot }}", ENV{FORCE_NM_UNMANAGED}=="1", TEST=="/usr/sbin/netplan", \
+            RUN+="/usr/bin/systemd-run --no-block --property=ConditionPathExists=/sys%E{DEVPATH} /usr/sbin/netplan set network.ethernets.%E{ID_NET_NAME_PATH}=null"
+            SUBSYSTEM=="net", ACTION=="add|move", ENV{ID_PATH}=="pci-{{ v.Slot }}", TEST=="/usr/sbin/ip", \
+            RUN+="/usr/bin/systemd-run --no-block --property=ConditionPathExists=/sys%E{DEVPATH} /usr/sbin/ip link set dev %E{INTERFACE} up"
+            {% endfor %}
       register: copy_udev_rules
 
     - name: Refresh udev rules

--- a/roles/openvswitch/tasks/openvswitch.yml
+++ b/roles/openvswitch/tasks/openvswitch.yml
@@ -225,19 +225,6 @@
         _dpdk_keys: >-
           {{ _dpdk_bond.keys() | list + _dpdk_iface.keys() | list }}
 
-    - name: Assert that at least one IP address has been provided by the user
-      ansible.builtin.assert:
-        that: _ip_addrs | count > 0
-        fail_msg: Please define at least one IP address (otherwise all connectivity would be lost).
-      vars:
-        _ip_addrs: >-
-          {{ (ovs.iface.values() | list + ovs.br.values() | list) | selectattr('addrs', 'defined')
-                                                                  | map(attribute='addrs')
-                                                                  | flatten
-                                                                  | selectattr('cidr', 'defined')
-                                                                  | map(attribute='cidr')
-                                                                  | select }}
-
     - name: Assert addrs/gw/dns are not declared for br 'ports' and bond 'ifaces'
       ansible.builtin.assert:
         that: _matched | count == 0
@@ -373,7 +360,7 @@
           mode: u=rw,go=r
       register: template
 
-    - name: Switch to OVS networking
+    - name: Enable OVS networking
       ansible.builtin.systemd_service:
         daemon_reload: "{{ item.daemon_reload | d(omit) }}"
         name: "{{ item.name | d(omit) }}"

--- a/roles/openvswitch/tasks/openvswitch.yml
+++ b/roles/openvswitch/tasks/openvswitch.yml
@@ -221,19 +221,6 @@
         _dpdk_keys: >-
           {{ _dpdk_bond.keys() | list + _dpdk_iface.keys() | list }}
 
-    - name: Assert that at least one IP address has been provided by the user
-      ansible.builtin.assert:
-        that: _ip_addrs | count > 0
-        fail_msg: Please define at least one IP address (otherwise all connectivity would be lost).
-      vars:
-        _ip_addrs: >-
-          {{ (ovs.iface.values() | list + ovs.br.values() | list) | selectattr('addrs', 'defined')
-                                                                  | map(attribute='addrs')
-                                                                  | flatten
-                                                                  | selectattr('cidr', 'defined')
-                                                                  | map(attribute='cidr')
-                                                                  | select }}
-
     - name: Assert addrs/gw/dns are not declared for br 'ports' and bond 'ifaces'
       ansible.builtin.assert:
         that: _matched | count == 0
@@ -369,7 +356,7 @@
           mode: u=rw,go=r
       register: template
 
-    - name: Switch to OVS networking
+    - name: Enable OVS networking
       ansible.builtin.systemd_service:
         daemon_reload: "{{ item.daemon_reload | d(omit) }}"
         name: "{{ item.name | d(omit) }}"

--- a/roles/openvswitch/templates/opennebula-ovs.sh.jinja
+++ b/roles/openvswitch/templates/opennebula-ovs.sh.jinja
@@ -189,6 +189,10 @@ ip route replace default via '{{ gw }}' || die 'Failed to replace default route 
 
 # --- Nameserver configuration
 
+{% if (ovs.iface.values() | list + ovs.br.values() | list) | selectattr('dns', 'defined')
+                                                           | selectattr('dns', 'sequence')
+                                                           | selectattr('dns', 'truthy')
+                                                           | count > 0 %}
 if type -p systemctl resolvectl &>/dev/null && [[ "$(systemctl is-enabled systemd-resolved.service)" != not-found ]]; then
     log 'Enabling systemd-resolved'
     if systemctl enable --now systemd-resolved.service; then
@@ -206,6 +210,7 @@ if type -p systemctl resolvectl &>/dev/null && [[ "$(systemctl is-enabled system
 {% endif %}
 {% endfor %}
 fi
+{% endif %}
 
 # --- Networking refresh
 

--- a/roles/openvswitch/templates/opennebula-ovs.sh.jinja
+++ b/roles/openvswitch/templates/opennebula-ovs.sh.jinja
@@ -62,20 +62,6 @@ ovs-vsctl --no-headings --columns=name find Bridge 'external_ids:one-deploy-br!=
     fi
 done
 
-# --- Networking cleanup
-
-if type -p systemctl &>/dev/null && systemctl is-active --quiet NetworkManager; then
-    log 'Stopping and disabling NetworkManager'
-    systemctl disable NetworkManager || log 'WARNING: Failed to disable NetworkManager'
-    systemctl stop NetworkManager || log 'WARNING: Failed to stop NetworkManager'
-fi
-
-if type -p netplan &>/dev/null && netplan status -f json | jq -re '."netplan-global-state"."online"' &>/dev/null; then
-    log 'Disabling Netplan'
-    find /etc/netplan/ -type f -name '*.yaml' -exec mv {} {}.bak \;
-    netplan apply || log 'WARNING: Failed to disable Netplan'
-fi
-
 # --- Bridge creation
 
 {% for br in ovs.br %}


### PR DESCRIPTION
The main purpose of helper/pci role is to pass devices to OpenNebula, in case those are not bound to the vfio-pci driver we forcefully exclude them from NetworkManager's managed devices.