### PR TITLE
F OpenNebula/one#7673: DPDK live migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ __pycache__/
 .vscode
 .ansible/
 .venv/
+.DS_Store

--- a/roles/openvswitch/tasks/vhost.yml
+++ b/roles/openvswitch/tasks/vhost.yml
@@ -53,15 +53,20 @@
                 exit 78 # EREMCHG
               fi
             stdin: |
-              module dpdk_virt 1.0;
+              module dpdk_virt 1.1;
               require {
                   type openvswitch_t;
                   type virt_var_run_t;
+                  type svirt_t;
+                  type svirt_tmpfs_t;
                   class dir { search getattr read open };
-                  class sock_file { write getattr append };
+                  class sock_file { write getattr append unlink };
+                  class file { map getattr };
               }
               allow openvswitch_t virt_var_run_t:dir { search getattr read open };
               allow openvswitch_t virt_var_run_t:sock_file { write getattr append };
+              allow svirt_t virt_var_run_t:sock_file unlink;
+              allow openvswitch_t svirt_tmpfs_t:file { map getattr };
             executable: /bin/bash
           register: shell_dpdk_virt
           changed_when:


### PR DESCRIPTION
Update DPDK selinux module to handle extra operation required for more VM operations. Prevents unlink permission issues when resuming or migrating VMs.

Reference for the problems found

```
[root@sm14 ~]# ausearch -m avc -ts recent
----
time->Tue Jul 21 05:44:23 2026
type=PROCTITLE msg=audit(1784627063.147:23472): proctitle=2F7573722F62696E2F71656D752D6B766D2D6F6E65002D6E616D650067756573743D6F6E652D3137312C64656275672D746872656164733D6F6E002D53002D6F626A656374007B22716F6D2D74797065223A22736563726574222C226964223A226D61737465724B657930222C22666F726D6174223A22726177222C2266696C
type=SYSCALL msg=audit(1784627063.147:23472): arch=c000003e syscall=87 success=yes exit=0 a0=556e8817fe80 a1=0 a2=556e8817fe80 a3=556e8817fe70 items=0 ppid=1 pid=3697538 auid=4294967295 uid=9869 gid=9869 euid=9869 suid=9869 fsuid=9869 egid=9869 sgid=9869 fsgid=9869 tty=(none) ses=4294967295 comm="qemu-kvm-one" exe="/usr/libexec/qemu-kvm" subj=system_u:system_r:svirt_t:s0:c247,c253 key=(null)
type=AVC msg=audit(1784627063.147:23472): avc:  denied  { unlink } for  pid=3697538 comm="qemu-kvm-one" name="one-171-0" dev="tmpfs" ino=26826 scontext=system_u:system_r:svirt_t:s0:c247,c253 tcontext=system_u:object_r:virt_var_run_t:s0 tclass=sock_file permissive=1
----
time->Tue Jul 21 05:45:53 2026
type=PROCTITLE msg=audit(1784627153.897:23656): proctitle=2F7573722F62696E2F71656D752D6B766D2D6F6E65002D6E616D650067756573743D6F6E652D3137312C64656275672D746872656164733D6F6E002D53002D6F626A656374007B22716F6D2D74797065223A22736563726574222C226964223A226D61737465724B657930222C22666F726D6174223A22726177222C2266696C
type=SYSCALL msg=audit(1784627153.897:23656): arch=c000003e syscall=87 success=yes exit=0 a0=556e8817fb40 a1=0 a2=0 a3=27 items=0 ppid=1 pid=3697538 auid=4294967295 uid=9869 gid=9869 euid=9869 suid=9869 fsuid=9869 egid=9869 sgid=9869 fsgid=9869 tty=(none) ses=4294967295 comm="qemu-kvm-one" exe="/usr/libexec/qemu-kvm" subj=system_u:system_r:svirt_t:s0:c247,c253 key=(null)
type=AVC msg=audit(1784627153.897:23656): avc:  denied  { unlink } for  pid=3697538 comm="qemu-kvm-one" name="one-171-0" dev="tmpfs" ino=26963 scontext=system_u:system_r:svirt_t:s0:c247,c253 tcontext=system_u:object_r:virt_var_run_t:s0 tclass=sock_file permissive=1
----
time->Tue Jul 21 05:48:18 2026
type=PROCTITLE msg=audit(1784627298.552:24120): proctitle=6F76732D767377697463686400756E69783A2F7661722F72756E2F6F70656E767377697463682F64622E736F636B002D76636F6E736F6C653A656D6572002D767379736C6F673A657272002D7666696C653A696E666F002D2D6D6C6F636B616C6C002D2D75736572006F70656E767377697463683A68756765746C626673002D
type=SYSCALL msg=audit(1784627298.552:24120): arch=c000003e syscall=9 success=no exit=-13 a0=0 a1=8000 a2=3 a3=1 items=0 ppid=1 pid=4686 auid=4294967295 uid=989 gid=987 euid=989 suid=989 fsuid=989 egid=987 sgid=987 fsgid=987 tty=(none) ses=4294967295 comm="dpdk-vhost-evt" exe="/usr/sbin/ovs-vswitchd" subj=system_u:system_r:openvswitch_t:s0 key=(null)
type=AVC msg=audit(1784627298.552:24120): avc:  denied  { map } for  pid=4686 comm="dpdk-vhost-evt" path=2F6D656D66643A76686F73742D6C6F67202864656C6574656429 dev="tmpfs" ino=54273 scontext=system_u:system_r:openvswitch_t:s0 tcontext=system_u:object_r:svirt_tmpfs_t:s0 tclass=file permissive=0
----
time->Tue Jul 21 05:48:18 2026
type=PROCTITLE msg=audit(1784627298.552:24121): proctitle=6F76732D767377697463686400756E69783A2F7661722F72756E2F6F70656E767377697463682F64622E736F636B002D76636F6E736F6C653A656D6572002D767379736C6F673A657272002D7666696C653A696E666F002D2D6D6C6F636B616C6C002D2D75736572006F70656E767377697463683A68756765746C626673002D
type=SYSCALL msg=audit(1784627298.552:24121): arch=c000003e syscall=5 success=no exit=-13 a0=269 a1=7f238c5dd368 a2=ffffffffffffea00 a3=1 items=0 ppid=1 pid=4686 auid=4294967295 uid=989 gid=987 euid=989 suid=989 fsuid=989 egid=987 sgid=987 fsgid=987 tty=(none) ses=4294967295 comm="dpdk-vhost-evt" exe="/usr/sbin/ovs-vswitchd" subj=system_u:system_r:openvswitch_t:s0 key=(null)
type=AVC msg=audit(1784627298.552:24121): avc:  denied  { getattr } for  pid=4686 comm="dpdk-vhost-evt" path=2F6D656D66643A76686F73742D6C6F67202864656C6574656429 dev="tmpfs" ino=54273 scontext=system_u:system_r:openvswitch_t:s0 tcontext=system_u:object_r:svirt_tmpfs_t:s0 tclass=file permissive=0
[root@sm14 ~]# date
Tue Jul 21 05:51:49 AM EDT 2026
```

The VM migration fails with a cryptic qemu error

```log
load of migration failed: Input/output error
```

but unlinking on resume is quite explicit

```log
internal error: QEMU unexpectedly closed the monitor (vm='one-171'): 2026-07-21T10:03:59.669720Z qemu-kvm-one: -chardev socket,id=charnet0,path=/var/run/one/vhost-socks/one-171-0,server=on: Failed to unlink socket /var/run/one/vhost-socks/one-171-0: Permission denied
```
