### PR TITLE
F #239: Conditional ownership

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ __pycache__/
 .vscode
 .ansible/
 .venv/
+.DS_Store

--- a/roles/helper/fstab/README.md
+++ b/roles/helper/fstab/README.md
@@ -11,16 +11,16 @@ N/A
 Role Variables
 --------------
 
-| Name             | Type    | Default                          | Example                   | Description                                           |
-|------------------|---------|----------------------------------|---------------------------|-------------------------------------------------------|
-| `fstab`          | `list`  | `[]`                             |                           | A list of mount definitions.                          |
-| `fstab[].src`    | `str`   | undefined                        | `server:/srv/shared`      | Device to be mounted on path.                         |
-| `fstab[].path`   | `str`   | undefined                        | `/var/lib/one/datastores` | Path to the mountpoint.                               |
-| `fstab[].fstype` | `str`   | undefined                        | `nfs`                     | Filesystem type.                                      |
-| `fstab[].opts`   | `str`   | `rw,relatime,comment=one-deploy` |                           | Mount options.                                        |
-| `fstab[].owner`  | `str`   | `9869`                           |                           | Name/UID of the user that should own the mountpoint.  |
-| `fstab[].group`  | `str`   | `9869`                           |                           | Name/GID of the group that should own the mountpoint. |
-| `fstab[].mode`   | `str`   | `u=rwx,g=rx,o=`                  |                           | The permissions the resulting mountpoint should have. |
+| Name             | Type    | Default                          | Example                   | Description                                                              |
+|------------------|---------|----------------------------------|---------------------------|--------------------------------------------------------------------------|
+| `fstab`          | `list`  | `[]`                             |                           | A list of mount definitions.                                             |
+| `fstab[].src`    | `str`   | undefined                        | `server:/srv/shared`      | Device to be mounted on path.                                            |
+| `fstab[].path`   | `str`   | undefined                        | `/var/lib/one/datastores` | Path to the mountpoint.                                                  |
+| `fstab[].fstype` | `str`   | undefined                        | `nfs`                     | Filesystem type.                                                         |
+| `fstab[].opts`   | `str`   | `rw,relatime,comment=one-deploy` |                           | Mount options.                                                           |
+| `fstab[].owner`  | `str`   | `9869`                           |                           | Name/UID of the user that should own the mountpoint. Use `null` to skip  |
+| `fstab[].group`  | `str`   | `9869`                           |                           | Name/GID of the group that should own the mountpoint. Use `null` to skip |
+| `fstab[].mode`   | `str`   | `u=rwx,g=rx,o=`                  |                           | The permissions the resulting mountpoint should have. Use `null` to skip |
 
 Dependencies
 ------------

--- a/roles/helper/fstab/tasks/main.yml
+++ b/roles/helper/fstab/tasks/main.yml
@@ -66,9 +66,9 @@
     - name: Ensure mountpoints with desired permissions exist
       ansible.builtin.file:
         path: "{{ item.path }}"
-        owner: "{{ item.owner }}"
-        group: "{{ item.group }}"
-        mode: "{{ item.mode }}"
+        owner: "{{ item.owner | default(omit, true) }}"
+        group: "{{ item.group | default(omit, true) }}"
+        mode: "{{ item.mode | default(omit, true) }}"
         state: directory
       loop: "{{ _fstab }}"
 


### PR DESCRIPTION
In cases where mounting an NFS share, it happens that changing ownership is a not supported operation. There is `nobody:nobody` owning the mounted shared fs. 

The idea is to have the ownership being conditional. This would be the way to signal it.

```yaml
        owner: null
        group: null
        mode: null
```

Hi @sk4zuzu 👋 