### PR TITLE
Allow Ubuntu 26 to pass the 'ceph feature' supported check if tentacl…

### DIFF
--- a/roles/precheck/pre_reboot/tasks/ceph.yml
+++ b/roles/precheck/pre_reboot/tasks/ceph.yml
@@ -54,6 +54,7 @@
         Ubuntu:
           '22': [community]
           '24': [community]
+          '26': [distro]
         AlmaLinux:
           '9': [community]
           '10': [community]


### PR DESCRIPTION
…e is used. tentacle is the default version for Ubuntu 26.04

This request is made with the assumption that Ubuntu 26.04 will be supported at one point.
I did try to get it running using Ubuntu 26.04. It looks promising so far. The only change required, for the ceph part, was to update the "ceph supported" check.

Ubuntu 26.04 comes with ceph tentacle release as default therefore the origin should be "distro".