### PR TITLE
M #: auto virtio queues for network interfaces

### DIFF
--- a/roles/infra/templates/frontend.xml.jinja
+++ b/roles/infra/templates/frontend.xml.jinja
@@ -99,7 +99,6 @@
 {% elif infra_bridge_type == 'openvswitch_dpdk' %}
     <interface type='vhostuser'>
       <source type='unix' path='{{ infra_dpdk_socket_path }}' mode='server'/>
-      <driver name='vhost' queues='2'/>
 {% endif %}
       <mac address='{{ context.ETH0_MAC | d("02:01:%02x:%02x:%02x:%02x" | format(*(context.ETH0_IP.split(".") | map("int")))) }}'/>
 {% if infra_bridge_type == 'openvswitch' %}
@@ -111,6 +110,7 @@
       </vlan>
 {% endif %}
       <model type='virtio'/>
+      <driver name='vhost' queues='{{ vcpu_static }}'/>
       <alias name='net0'/>
     </interface>
 {% endif %}


### PR DESCRIPTION
Set frontend VM nic queues automatically based on VCPU, following  [opennebula behavior](https://github.com/OpenNebula/one/blob/master/src/vmm/LibVirtDriverKVM.cc#L2000-L2017).