### PR TITLE
M #-: Pass ssh_args* to add_host for master and leader (fix)

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -43,9 +43,21 @@
 - name: Dynamically add ungrouped inventory host to represent the Master
   ansible.builtin.add_host:
     name: master
-    ansible_host: "{{ federation.master_host }}"
-    ansible_user: "{{ federation.master_user }}"
-    ansible_python_interpreter: "{{ ansible_python_interpreter }}"
+    ansible_host: >-
+      {{ federation.master_host }}
+    ansible_user: >-
+      {{ federation.master_user }}
+    ansible_python_interpreter: >-
+      {{ ansible_python_interpreter }}
+    ansible_ssh_args: >-
+      {{ lookup('ansible.builtin.config', 'ssh_args', plugin_type='connection',
+                                                      plugin_name='ssh') }}
+    ansible_ssh_common_args: >-
+      {{ lookup('ansible.builtin.config', 'ssh_common_args', plugin_type='connection',
+                                                             plugin_name='ssh') }}
+    ansible_ssh_extra_args: >-
+      {{ lookup('ansible.builtin.config', 'ssh_extra_args', plugin_type='connection',
+                                                            plugin_name='ssh') }}
   changed_when: false
   when:
     - federation.role != 'STANDALONE'

--- a/roles/opennebula/leader/tasks/main.yml
+++ b/roles/opennebula/leader/tasks/main.yml
@@ -24,10 +24,21 @@
         - name: Dynamically add ungrouped inventory host to represent the Leader
           ansible.builtin.add_host:
             name: leader
-            ansible_host: "{{ hostvars[_leader].ansible_host | d(_leader) }}"
-            ansible_user: "{{ hostvars[_federation.groups.frontend[0]].ansible_user }}"
+            ansible_host: >-
+              {{ hostvars[_leader].ansible_host | d(_leader) }}
+            ansible_user: >-
+              {{ hostvars[_federation.groups.frontend[0]].ansible_user }}
             ansible_python_interpreter: >-
               {{ hostvars[_federation.groups.frontend[0]].ansible_python_interpreter }}
+            ansible_ssh_args: >-
+              {{ lookup('ansible.builtin.config', 'ssh_args', plugin_type='connection',
+                                                              plugin_name='ssh') }}
+            ansible_ssh_common_args: >-
+              {{ lookup('ansible.builtin.config', 'ssh_common_args', plugin_type='connection',
+                                                                     plugin_name='ssh') }}
+            ansible_ssh_extra_args: >-
+              {{ lookup('ansible.builtin.config', 'ssh_extra_args', plugin_type='connection',
+                                                                    plugin_name='ssh') }}
           changed_when: false
           when: _leader is defined
           vars:


### PR DESCRIPTION
This restores a simple alternative to the helper/bastion role when the cluster VIP is set inside an isolated subnet.